### PR TITLE
Fix first-pick marker placement

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.59.4",
+  "version": "1.59.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.59.4",
+      "version": "1.59.5",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.59.4",
+  "version": "1.59.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/RankingsTable.tsx
+++ b/frontend/src/components/RankingsTable.tsx
@@ -81,6 +81,16 @@ export function RankingsTable({ rows, teams, source, sortKey, sortDirection, dra
   }).sort((left, right) => left.overallPick - right.overallPick)
   const markerGroups = new Map<number, DraftMarker[]>()
   draftMarkers.forEach((marker) => {
+    // The active pick is the next available roster choice, not the row whose
+    // source rank happens to equal the overall pick number. This matters when
+    // another manager drafts an arbitrary player (for example rank 5) before
+    // our first pick: the marker must move to the top available player.
+    if (marker.isCurrent) {
+      const firstAvailableIndex = rows.findIndex((row) => !drafted.has(rankingId(row)))
+      const index = firstAvailableIndex === -1 ? rows.length : firstAvailableIndex
+      markerGroups.set(index, [...(markerGroups.get(index) ?? []), marker])
+      return
+    }
     const firstAvailableIndex = rows.findIndex((row) => typeof row.sourceRank === 'number' && row.sourceRank >= marker.overallPick && !drafted.has(rankingId(row)))
     const lastPastPickIndex = rows.reduce((lastIndex, row, index) => typeof row.sourceRank === 'number' && row.sourceRank >= marker.overallPick && drafted.has(rankingId(row)) ? index : lastIndex, -1)
     const availableIndex = firstAvailableIndex === -1 ? rows.length : firstAvailableIndex

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -139,9 +139,18 @@ test('draft divider stays below past picks even when a lower-ranked player was d
   await page.getByRole('button', { name: "Mark drafted Ja'Marr Chase" }).first().click()
   const divider = page.locator('[data-draft-divider][data-draft-marker-overall="2"]')
   await expect(divider).toHaveCount(1)
-  await expect(divider.locator('xpath=preceding-sibling::tr[1]')).toContainText("Ja'Marr Chase")
+  await expect(divider.locator('xpath=following-sibling::tr[1]')).toContainText('Jahmyr Gibbs')
   await page.getByRole('button', { name: "Undo drafted Ja'Marr Chase" }).first().click()
   await expect(page.locator('[data-draft-divider][data-draft-marker-overall="2"]')).toHaveCount(1)
+})
+
+test('first pick marker moves to the top available player when rank five is drafted first', async ({ page }) => {
+  await page.goto('./')
+  await page.getByRole('button', { name: 'Mark drafted Jaxon Smith-Njigba' }).first().click()
+  const divider = page.locator('[data-draft-divider][data-draft-marker-current="true"]')
+  await expect(divider).toContainText('Your pick')
+  await expect(divider.locator('xpath=following-sibling::tr[1]')).toContainText('Jahmyr Gibbs')
+  await expect(page.getByRole('button', { name: 'Undo drafted Jaxon Smith-Njigba' }).first()).toBeVisible()
 })
 
 test('draft spot defaults to 2 and persists through settings and reload', async ({ page }) => {


### PR DESCRIPTION
## Summary\n- Place the active snake-draft marker before the first available player, independent of that player's source rank.\n- Correct the second-pick case when an arbitrary rank-five player is drafted first.\n- Add Chromium coverage for rank-five-first and lower-ranked drafted edge cases.\n\n## Validation\n- Lint, build, and 16 unit tests passed\n- Full Chromium UI suite: 64 tests passed\n\nRelease target: v1.59.5