### PR TITLE
feat: ship Studio Mint dashboard theme

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.59.5",
+  "version": "1.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.59.5",
+      "version": "1.60.0",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.59.5",
+  "version": "1.60.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -189,5 +189,5 @@ export default function App() {
   if (window.location.pathname.endsWith('/draft-cutoff-mockups')) return <DraftCutoffMockups />
   if (window.location.pathname.endsWith('/column-mockups')) return <ColumnMockups />
   if (window.location.pathname.endsWith('/mockups')) return <ThemeMockups />
-  return <AppData />
+  return <div className="app-theme app-theme--studio-mint"><AppData /></div>
 }

--- a/frontend/src/components/ThemeMockups.tsx
+++ b/frontend/src/components/ThemeMockups.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-type ThemeId = 'quiet' | 'scoreboard' | 'command' | 'editorial' | 'field'
+type ThemeId = 'quiet' | 'scoreboard' | 'command' | 'editorial' | 'field' | 'studio-mint'
 
 const themes: Array<{ id: ThemeId; name: string; eyebrow: string; font: string; description: string }> = [
   { id: 'quiet', name: 'Quiet Utility', eyebrow: 'Option 01', font: 'System sans', description: 'A compact wordmark, calm navigation, and no wasted height.' },
@@ -8,6 +8,7 @@ const themes: Array<{ id: ThemeId; name: string; eyebrow: string; font: string; 
   { id: 'command', name: 'Command Strip', eyebrow: 'Option 03', font: 'Condensed sans', description: 'A denser control-room header built for quick scanning.' },
   { id: 'editorial', name: 'Editorial Index', eyebrow: 'Option 04', font: 'Humanist sans', description: 'A little more personality with a restrained magazine-like rhythm.' },
   { id: 'field', name: 'Field Notes', eyebrow: 'Option 05', font: 'Mono accents', description: 'A soft green live-state marker with a practical draft-room feel.' },
+  { id: 'studio-mint', name: 'Studio Mint', eyebrow: 'Option 06', font: 'Warm sans · mint accents', description: 'A warm studio surface, mint controls, and quiet data contrast.' },
 ]
 
 const players = [
@@ -47,7 +48,7 @@ export function ThemeMockups() {
   const activeTheme = themes.find((theme) => theme.id === selected) ?? themes[0]
   return <main className={`theme-lab theme-lab--${selected}`}>
     <div className="theme-lab__topbar"><a className="theme-lab__back" href="./">← Back to dashboard</a><span className="mock-eyebrow">RankingsDiff · Theme lab</span><span className="theme-lab__status">Responsive mockups</span></div>
-    <header className="theme-lab__intro"><div><span className="mock-eyebrow">A visual direction study</span><h1>Choose a calmer, more connected header.</h1><p>Five responsive HTML header mockups using the existing RankingsDiff language. Each option stays compact so the rankings remain the main event.</p></div><div className="theme-lab__choice"><span>Selected direction</span><strong>{activeTheme.name}</strong><button className="mock-primary" type="button" onClick={() => setSettingsOpen((open) => !open)}>{settingsOpen ? 'Hide settings' : 'Preview settings'}</button></div></header>
+    <header className="theme-lab__intro"><div><span className="mock-eyebrow">A visual direction study</span><h1>Choose a calmer, more connected header.</h1><p>Six responsive HTML header mockups using the existing RankingsDiff language. Each option stays compact so the rankings remain the main event.</p></div><div className="theme-lab__choice"><span>Selected direction</span><strong>{activeTheme.name}</strong><button className="mock-primary" type="button" onClick={() => setSettingsOpen((open) => !open)}>{settingsOpen ? 'Hide settings' : 'Preview settings'}</button></div></header>
     <section className="theme-options" aria-label="Header options">{themes.map((theme) => <button type="button" key={theme.id} className={`theme-option theme-option--${theme.id}${theme.id === selected ? ' is-selected' : ''}`} onClick={() => setSelected(theme.id)}><span className="theme-option__swatches"><i /><i /><i /></span><span className="mock-eyebrow">{theme.eyebrow}</span><strong>{theme.name}</strong><small className="theme-option__font">{theme.font}</small><small>{theme.description}</small><span className="theme-option__check" aria-hidden="true">{theme.id === selected ? '✓' : '○'}</span></button>)}</section>
     <section className="mock-browser" aria-label={`${activeTheme.name} dashboard preview`}>
       <div className="mock-browser__chrome"><span /><span /><span /><small>{activeTheme.name} · rankingsdiff</small><b>↗</b></div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -54,6 +54,56 @@ button { cursor: pointer; transition: color .15s ease, background .15s ease, bor
 button:active { transform: translateY(1px); }
 a { color: inherit; }
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+
+/* Studio Mint: a warm, low-noise surface for the live board. All existing
+   controls inherit these semantic tokens, so draft state, filters, roster
+   slots, logos, and the next-pick divider keep their behavior unchanged. */
+.app-theme--studio-mint {
+  --ink: #183b3b;
+  --muted: #5d7977;
+  --surface: #edf7f3;
+  --panel: #fffdf9;
+  --panel-soft: #f3fbf7;
+  --line: #cce3dc;
+  --accent: #168f7a;
+  --accent-2: #72c8b0;
+  --accent-soft: #e0f4ee;
+  --danger: #b23a4b;
+  --warning: #a76722;
+  --good: #157b62;
+  --danger-soft: #fff1f3;
+  --target: #956515;
+  --target-border: #e5c77f;
+  --target-soft: #fff7df;
+  --target-hover: #fffbed;
+  --target-hover-border: #d9bd73;
+  --toggle-off: #c8dad6;
+  --accent-hover: #0f7668;
+  --shadow-sm: 0 2px 6px rgb(24 59 59 / 7%);
+  --shadow-md: 0 8px 24px rgb(24 59 59 / 9%);
+  --shadow-lg: 0 18px 48px rgb(24 59 59 / 12%);
+  --shadow-xl: 0 30px 90px rgb(24 59 59 / 24%);
+  --qb: #7b63c6;
+  --rb: #149b84;
+  --wr: #df8b3f;
+  --te: #3689c7;
+  min-height: 100vh;
+  color: var(--ink);
+  background: linear-gradient(145deg, #e8f6f1 0%, #f8fbf8 58%, #f0f8f4 100%);
+}
+body:has(.app-theme--studio-mint) { background: #edf7f3; }
+.app-theme--studio-mint .hero--editorial { border-bottom-color: var(--line); }
+.app-theme--studio-mint .hero__mark { box-shadow: 0 10px 24px rgb(22 143 122 / 18%); }
+.app-theme--studio-mint .loading-shell { border-color: var(--line); background: linear-gradient(135deg, rgb(255 253 249 / 98%), rgb(224 244 238 / 88%)); }
+.app-theme--studio-mint .loading-mark { border-color: rgb(22 143 122 / 28%); box-shadow: 0 12px 26px rgb(22 143 122 / 20%); }
+.app-theme--studio-mint .settings-trigger { border-color: color-mix(in srgb, var(--accent) 24%, var(--line)); background: linear-gradient(135deg, var(--panel), var(--accent-soft)); box-shadow: var(--shadow-md); }
+.app-theme--studio-mint .settings-trigger:hover { border-color: color-mix(in srgb, var(--accent) 52%, var(--line)); box-shadow: var(--shadow-lg); }
+.app-theme--studio-mint .settings-trigger__icon { background: linear-gradient(135deg, var(--accent), var(--accent-2)); box-shadow: 0 8px 18px color-mix(in srgb, var(--accent) 24%, transparent); }
+.app-theme--studio-mint .settings-layer { background: color-mix(in srgb, var(--ink) 34%, transparent); }
+.app-theme--studio-mint .settings-popover { border-color: var(--line); background: var(--panel); box-shadow: var(--shadow-xl); }
+.app-theme--studio-mint .settings-section { border-color: var(--line); background: linear-gradient(135deg, var(--panel), var(--panel-soft)); box-shadow: var(--shadow-sm); }
+.app-theme--studio-mint .settings-section--sheet { border-color: color-mix(in srgb, var(--accent) 22%, var(--line)); background: linear-gradient(135deg, var(--accent-soft), var(--panel)); }
+.app-theme--studio-mint .settings-preference-card, .app-theme--studio-mint .settings-tools-grid .draft-state-controls { border-color: var(--line); background: color-mix(in srgb, var(--panel) 88%, var(--panel-soft)); }
 .dashboard { width: min(1440px, calc(100% - 40px)); margin: 0 auto; padding: 20px 0 56px; }
 .loading-shell { min-height: min(620px, calc(100vh - 80px)); display: flex; flex-direction: column; justify-content: center; align-items: flex-start; padding: 48px clamp(20px, 7vw, 96px); border: 1px solid rgba(213,221,235,.95); border-radius: 24px; background: linear-gradient(135deg, rgba(255,255,255,.96), rgba(238,240,255,.82)); box-shadow: var(--shadow); }
 .loading-mark { display: flex; width: 64px; height: 64px; align-items: center; justify-content: center; gap: 1px; margin-bottom: 24px; border: 1px solid rgba(79,93,228,.25); border-radius: 20px; color: #fff; background: linear-gradient(135deg, var(--accent), var(--accent-2)); box-shadow: 0 12px 26px rgba(79,93,228,.24); font-weight: 950; letter-spacing: -.13em; }
@@ -1387,6 +1437,7 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 .theme-lab { --lab-bg: #f3f5f9; --lab-surface: #fff; --lab-surface-2: #f8f9fd; --lab-ink: #172033; --lab-muted: #697386; --lab-line: #dfe4ee; --lab-primary: #4f5de4; --lab-primary-soft: #eef0ff; --lab-positive: #16805d; --lab-font: "Avenir Next", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif; --lab-display: "Avenir Next", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif; min-height: 100vh; padding: 18px clamp(16px, 4vw, 64px) 48px; color: var(--lab-ink); background: var(--lab-bg); font-family: var(--lab-font); }
 .theme-lab--command { --lab-bg: #101826; --lab-surface: #192336; --lab-surface-2: #202c42; --lab-ink: #edf3ff; --lab-muted: #9daac0; --lab-line: #34425a; --lab-primary: #87a8ff; --lab-primary-soft: #283a65; --lab-positive: #57d4a4; --lab-font: "Arial Narrow", "Roboto Condensed", "Helvetica Neue", Arial, sans-serif; --lab-display: "Arial Narrow", "Roboto Condensed", "Helvetica Neue", Arial, sans-serif; }
 .theme-lab--midnight { --lab-bg: #0b111c; --lab-surface: #121b2a; --lab-surface-2: #182438; --lab-ink: #f2f6ff; --lab-muted: #9ba8bb; --lab-line: #2a3b54; --lab-primary: #75e0ca; --lab-primary-soft: #173a40; --lab-positive: #75e0ca; --lab-font: "SF Mono", Menlo, Monaco, Consolas, monospace; --lab-display: "SF Mono", Menlo, Monaco, Consolas, monospace; }
+.theme-lab--studio-mint { --lab-bg: #edf7f3; --lab-surface: #fffdf9; --lab-surface-2: #f3fbf7; --lab-ink: #183b3b; --lab-muted: #5d7977; --lab-line: #cce3dc; --lab-primary: #168f7a; --lab-primary-soft: #e0f4ee; --lab-positive: #157b62; --lab-font: "Avenir Next", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif; --lab-display: "Avenir Next", "Helvetica Neue", ui-sans-serif, system-ui, sans-serif; }
 .theme-lab__topbar, .theme-lab__intro, .theme-options, .theme-lab__footer { width: min(1240px, 100%); margin-inline: auto; }
 .theme-lab__topbar { display: flex; align-items: center; gap: 18px; color: var(--lab-muted); font-size: .78rem; }
 .theme-lab__back { color: var(--lab-ink); font-weight: 800; text-decoration: none; }
@@ -1495,6 +1546,10 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 .mock-dashboard__header--field .mock-brand::after { content: "LIVE BOARD"; margin-left: 4px; padding: 4px 6px; border: 1px solid color-mix(in srgb, var(--lab-primary) 35%, transparent); border-radius: 5px; color: var(--lab-primary); font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .56rem; font-weight: 900; letter-spacing: .08em; }
 .mock-dashboard__header--field .mock-header-status { display: grid; gap: 2px; margin-left: auto; }
 .mock-dashboard__header--field .mock-header-status strong { color: var(--lab-primary); font-size: .78rem; }
+.mock-dashboard__header--studio-mint { padding: 10px 12px; border: 1px solid var(--lab-line); border-radius: 12px; background: var(--lab-surface-2); }
+.mock-dashboard__header--studio-mint .mock-brand::after { content: "STUDIO MINT"; margin-left: 4px; padding: 4px 6px; border: 1px solid color-mix(in srgb, var(--lab-primary) 35%, transparent); border-radius: 5px; color: var(--lab-primary); font-size: .56rem; font-weight: 900; letter-spacing: .08em; }
+.mock-dashboard__header--studio-mint .mock-header-status { display: grid; gap: 2px; margin-left: auto; }
+.mock-dashboard__header--studio-mint .mock-header-status strong { color: var(--lab-primary); font-size: .78rem; }
 @media (max-width: 1100px) { .theme-options { grid-template-columns: repeat(3, minmax(0, 1fr)); } }
 @media (max-width: 760px) { .theme-options { grid-template-columns: repeat(2, minmax(0, 1fr)); } .mock-header-context, .mock-header-status { display: none !important; } }
 @media (max-width: 480px) { .theme-options { grid-template-columns: 1fr; } }

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -168,13 +168,15 @@ test('draft spot defaults to 2 and persists through settings and reload', async 
   await expect(page.locator('.view-summary')).toContainText('5/10')
 })
 
-test('header mockup lab offers five compact directions', async ({ page }) => {
+test('header mockup lab offers six compact directions', async ({ page }) => {
   await page.goto('./mockups')
   await expect(page.getByRole('heading', { name: 'Choose a calmer, more connected header.' })).toBeVisible()
-  await expect(page.getByRole('region', { name: 'Header options' }).getByRole('button')).toHaveCount(5)
+  await expect(page.getByRole('region', { name: 'Header options' }).getByRole('button')).toHaveCount(6)
   await page.getByRole('button', { name: 'Close settings' }).click()
   await page.getByRole('button', { name: /Field Notes/ }).click()
   await expect(page.locator('.mock-dashboard__header--field')).toBeVisible()
+  await page.getByRole('button', { name: /Studio Mint/ }).click()
+  await expect(page.locator('.mock-dashboard__header--studio-mint')).toBeVisible()
   await expect(page.locator('body')).toHaveCSS('overflow-x', 'visible')
 })
 


### PR DESCRIPTION
## Summary
- apply the Studio Mint visual theme to the live dashboard
- align settings controls and surfaces with the theme tokens
- add Studio Mint to the responsive theme lab
- bump the frontend release to 1.60.0

## Validation
- `asdf exec npm --prefix frontend run lint`
- `asdf exec npm --prefix frontend test`
- `asdf exec npm --prefix frontend run build`
- `asdf exec npm --prefix frontend run test:ui` (64 Chromium tests)

## Release
This is a backward-compatible visual feature release: 1.60.0.