### PR TITLE
Preserve direct client routes on Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,8 @@ jobs:
         working-directory: frontend
       - name: Build frontend
         run: npm --prefix frontend run build
+      - name: Preserve client-side routes on GitHub Pages
+        run: cp frontend/dist/index.html frontend/dist/404.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/dist

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.66.0",
+      "version": "1.66.1",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Copy the built SPA entrypoint to `404.html` so direct client-side URLs such as `/draft-rankings/2025` load on GitHub Pages.
- Bump the patch release to 1.66.1.

## Testing
- Existing PR CI passed on the feature merge; this changes only Pages packaging and version metadata.