### PR TITLE
Add 2024 auction draft data

### DIFF
--- a/data/raw/2024/draft_rankings.csv
+++ b/data/raw/2024/draft_rankings.csv
@@ -1,0 +1,171 @@
+manager,rank,player,nfl_team,position,offer_amount
+Dane,14,Travis Kelce,KC,TE,21
+Dane,18,Amon-Ra St. Brown,Det,WR,59
+Dane,19,Travis Etienne Jr.,Jax,RB,40
+Dane,41,Stefon Diggs,Hou,WR,17
+Dane,42,Kenneth Walker III,Sea,RB,25
+Dane,52,C.J. Stroud,Hou,QB,9
+Dane,60,Calvin Ridley,Ten,WR,7
+Dane,61,Keenan Allen,Chi,WR,6
+Dane,78,Amari Cooper,Buf,WR,6
+Dane,89,Tony Pollard,Ten,RB,1
+Dane,97,Keon Coleman,Buf,WR,3
+Dane,99,Harrison Butker,KC,K,1
+Dane,109,Browns D/ST,Cle,D/ST,1
+Dane,119,Jordan Mason,Min,RB,1
+Dane,129,Cole Kmet,Chi,TE,1
+Dane,139,Jerry Jeudy,Cle,WR,1
+Dane,148,Justin Herbert,LAC,QB,1
+Nick H,17,Chris Olave,NO,WR,30
+Nick H,26,De'Von Achane,Mia,RB,26
+Nick H,28,Michael Pittman Jr.,Ind,WR,26
+Nick H,43,Alvin Kamara,NO,RB,31
+Nick H,46,Cooper Kupp,Sea,WR,31
+Nick H,53,DeVonta Smith,Phi,WR,22
+Nick H,69,Aaron Jones,Min,RB,8
+Nick H,75,Dalton Kincaid,Buf,TE,7
+Nick H,79,Raheem Mostert,LV,RB,5
+Nick H,81,Tyjae Spears,Ten,RB,2
+Nick H,86,Christian Kirk,Hou,WR,3
+Nick H,91,Kyler Murray,Ari,QB,2
+Nick H,94,Jayden Reed,GB,WR,1
+Nick H,114,Dallas Goedert,Phi,TE,1
+Nick H,115,Jameson Williams,Det,WR,2
+Nick H,124,Brandon Aubrey,Dal,K,1
+Nick H,134,Jets D/ST,NYJ,D/ST,1
+Diego,4,Bijan Robinson,Atl,RB,53
+Diego,9,A.J. Brown,Phi,WR,51
+Diego,21,Josh Jacobs,GB,RB,32
+Diego,22,Malik Nabers,NYG,WR,27
+Diego,50,Jalen Hurts,Phi,QB,20
+Diego,103,Jake Ferguson,Dal,TE,2
+Diego,104,Zack Moss,Cin,RB,2
+Diego,106,Brian Thomas Jr.,Jax,WR,2
+Diego,113,Tyler Allgeier,Atl,RB,1
+Diego,116,Hollywood Brown,KC,WR,2
+Diego,127,Adonai Mitchell,Ind,WR,2
+Diego,133,Blake Corum,LAR,RB,1
+Diego,143,Caleb Williams,Chi,QB,1
+Diego,151,Brandin Cooks,Dal,WR,1
+Diego,158,Dontayvion Wicks,GB,WR,1
+Diego,163,Younghoe Koo,Atl,K,1
+Diego,167,Seahawks D/ST,Sea,D/ST,1
+Jordan,10,Saquon Barkley,Phi,RB,50
+Jordan,15,Kyren Williams,LAR,RB,38
+Jordan,29,DJ Moore,Chi,WR,19
+Jordan,31,Josh Allen,Buf,QB,24
+Jordan,39,Xavier Worthy,KC,WR,11
+Jordan,48,Sam LaPorta,Det,TE,19
+Jordan,54,Tank Dell,Hou,WR,10
+Jordan,59,Terry McLaurin,Wsh,WR,11
+Jordan,82,Ladd McConkey,LAC,WR,3
+Jordan,85,Brian Robinson Jr.,Wsh,RB,1
+Jordan,87,David Montgomery,Det,RB,5
+Jordan,92,Brock Bowers,LV,TE,2
+Jordan,95,Rome Odunze,Chi,WR,3
+Jordan,125,Jordan Love,GB,QB,1
+Jordan,135,Gus Edwards,FA,RB,1
+Jordan,144,Dolphins D/ST,Mia,D/ST,1
+Jordan,152,Greg Zuerlein,NYJ,K,1
+Nick J,2,Garrett Wilson,NYJ,WR,44
+Nick J,6,Kirk Cousins,Atl,QB,1
+Nick J,23,Isiah Pacheco,KC,RB,39
+Nick J,25,Breece Hall,NYJ,RB,62
+Nick J,45,Rashee Rice,KC,WR,10
+Nick J,47,DK Metcalf,Pit,WR,28
+Nick J,71,Najee Harris,LAC,RB,4
+Nick J,74,Kyle Pitts,Atl,TE,2
+Nick J,96,Ezekiel Elliott,FA,RB,1
+Nick J,105,J.K. Dobbins,LAC,RB,2
+Nick J,126,Darnell Mooney,Atl,WR,1
+Nick J,136,DeAndre Hopkins,Bal,WR,1
+Nick J,145,Romeo Doubs,GB,WR,1
+Nick J,153,Curtis Samuel,Buf,WR,1
+Nick J,159,Chiefs D/ST,KC,D/ST,1
+Nick J,164,Adam Thielen,Car,WR,1
+Nick J,168,Cameron Dicker,LAC,K,1
+Luca,5,Jonathan Taylor,Ind,RB,46
+Luca,20,Justin Jefferson,Min,WR,60
+Luca,32,Davante Adams,LAR,WR,35
+Luca,33,Rachaad White,TB,RB,25
+Luca,68,Dak Prescott,Dal,QB,4
+Luca,70,Chris Godwin,TB,WR,7
+Luca,73,Zamir White,LV,RB,5
+Luca,80,George Kittle,SF,TE,2
+Luca,84,Austin Ekeler,Wsh,RB,2
+Luca,93,Courtland Sutton,Den,WR,2
+Luca,102,Bucky Irving,TB,RB,3
+Luca,108,Nick Chubb,Cle,RB,3
+Luca,111,Mike Williams,LAC,WR,1
+Luca,121,Jakobi Meyers,LV,WR,1
+Luca,123,Joshua Palmer,Buf,WR,2
+Luca,131,Ravens D/ST,Bal,D/ST,1
+Luca,141,Justin Tucker,Bal,K,1
+Sammy,3,CeeDee Lamb,Dal,WR,59
+Sammy,24,Drake London,Atl,WR,25
+Sammy,35,James Cook,Buf,RB,22
+Sammy,37,Joe Mixon,Hou,RB,20
+Sammy,49,D'Andre Swift,Chi,RB,13
+Sammy,55,Tee Higgins,Cin,WR,13
+Sammy,56,George Pickens,Pit,WR,8
+Sammy,57,Diontae Johnson,Bal,WR,6
+Sammy,58,Anthony Richardson,Ind,QB,11
+Sammy,63,Mark Andrews,Bal,TE,9
+Sammy,77,James Conner,Ari,RB,8
+Sammy,88,Jaylen Warren,Pit,RB,1
+Sammy,118,Zach Charbonnet,Sea,RB,1
+Sammy,128,Jayden Daniels,Wsh,QB,1
+Sammy,138,Steelers D/ST,Pit,D/ST,1
+Sammy,147,Dalton Schultz,Hou,TE,1
+Sammy,155,Jake Elliott,Phi,K,1
+Logan,1,Ja'Marr Chase,Cin,WR,56
+Logan,7,Jahmyr Gibbs,Det,RB,43
+Logan,11,Mike Evans,TB,WR,31
+Logan,40,Brandon Aiyuk,SF,WR,20
+Logan,51,Evan Engram,Den,TE,7
+Logan,62,Joe Burrow,Cin,QB,5
+Logan,66,Jaxon Smith-Njigba,Sea,WR,4
+Logan,67,Zay Flowers,Bal,WR,18
+Logan,83,Javonte Williams,Dal,RB,3
+Logan,90,Devin Singletary,NYG,RB,3
+Logan,98,Jerome Ford,Cle,RB,3
+Logan,107,Jonathon Brooks,Car,RB,2
+Logan,117,Ty Chandler,Min,RB,1
+Logan,137,Cowboys D/ST,Dal,D/ST,1
+Logan,146,Khalil Shakir,Buf,WR,1
+Logan,154,Trey Benson,Ari,RB,1
+Logan,160,Evan McPherson,Cin,K,1
+Mike,8,Christian McCaffrey,SF,RB,67
+Mike,12,Marvin Harrison Jr.,Ari,WR,36
+Mike,30,Jaylen Waddle,Mia,WR,23
+Mike,36,Deebo Samuel Sr.,Wsh,WR,34
+Mike,44,Patrick Mahomes,KC,QB,17
+Mike,65,Rhamondre Stevenson,NE,RB,7
+Mike,72,David Njoku,Cle,TE,4
+Mike,101,Jordan Addison,Min,WR,2
+Mike,112,Rico Dowdle,Car,RB,2
+Mike,122,Gabe Davis,Jax,WR,1
+Mike,132,49ers D/ST,SF,D/ST,1
+Mike,142,Jake Moody,SF,K,1
+Mike,150,Brock Purdy,SF,QB,1
+Mike,157,Khalil Herbert,Ind,RB,1
+Mike,162,Pat Freiermuth,Pit,TE,1
+Mike,166,Kyle Juszczyk,SF,RB,1
+Mike,170,Antonio Gibson,NE,RB,1
+Adrian,13,Puka Nacua,LAR,WR,39
+Adrian,16,Tyreek Hill,Mia,WR,70
+Adrian,27,Derrick Henry,Bal,RB,35
+Adrian,34,Lamar Jackson,Bal,QB,14
+Adrian,38,Nico Collins,Hou,WR,23
+Adrian,64,Trey McBride,Ari,TE,6
+Adrian,76,Christian Watson,GB,WR,3
+Adrian,100,Chase Brown,Cin,RB,1
+Adrian,110,Chuba Hubbard,Car,RB,1
+Adrian,120,Tyler Lockett,FA,WR,1
+Adrian,130,Jaleel McLaughlin,Den,RB,1
+Adrian,140,T.J. Hockenson,Min,TE,1
+Adrian,149,Saints D/ST,NO,D/ST,1
+Adrian,156,Ka'imi Fairbairn,Hou,K,1
+Adrian,161,DeMario Douglas,NE,WR,1
+Adrian,165,MarShawn Lloyd,GB,RB,1
+Adrian,169,Rashid Shaheed,NO,WR,1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.2",
+  "version": "1.66.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.66.2",
+      "version": "1.66.3",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.2",
+  "version": "1.66.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/public/data/2024/draft-rankings.json
+++ b/frontend/public/data/2024/draft-rankings.json
@@ -1,0 +1,1362 @@
+[
+  {
+    "manager": "Dane",
+    "rank": 14,
+    "player": "Travis Kelce",
+    "nfl_team": "KC",
+    "position": "TE",
+    "offer_amount": 21
+  },
+  {
+    "manager": "Dane",
+    "rank": 18,
+    "player": "Amon-Ra St. Brown",
+    "nfl_team": "Det",
+    "position": "WR",
+    "offer_amount": 59
+  },
+  {
+    "manager": "Dane",
+    "rank": 19,
+    "player": "Travis Etienne Jr.",
+    "nfl_team": "Jax",
+    "position": "RB",
+    "offer_amount": 40
+  },
+  {
+    "manager": "Dane",
+    "rank": 41,
+    "player": "Stefon Diggs",
+    "nfl_team": "Hou",
+    "position": "WR",
+    "offer_amount": 17
+  },
+  {
+    "manager": "Dane",
+    "rank": 42,
+    "player": "Kenneth Walker III",
+    "nfl_team": "Sea",
+    "position": "RB",
+    "offer_amount": 25
+  },
+  {
+    "manager": "Dane",
+    "rank": 52,
+    "player": "C.J. Stroud",
+    "nfl_team": "Hou",
+    "position": "QB",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Dane",
+    "rank": 60,
+    "player": "Calvin Ridley",
+    "nfl_team": "Ten",
+    "position": "WR",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Dane",
+    "rank": 61,
+    "player": "Keenan Allen",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Dane",
+    "rank": 78,
+    "player": "Amari Cooper",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Dane",
+    "rank": 89,
+    "player": "Tony Pollard",
+    "nfl_team": "Ten",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 97,
+    "player": "Keon Coleman",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Dane",
+    "rank": 99,
+    "player": "Harrison Butker",
+    "nfl_team": "KC",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 109,
+    "player": "Browns D/ST",
+    "nfl_team": "Cle",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 119,
+    "player": "Jordan Mason",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 129,
+    "player": "Cole Kmet",
+    "nfl_team": "Chi",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 139,
+    "player": "Jerry Jeudy",
+    "nfl_team": "Cle",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 148,
+    "player": "Justin Herbert",
+    "nfl_team": "LAC",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 17,
+    "player": "Chris Olave",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 30
+  },
+  {
+    "manager": "Nick H",
+    "rank": 26,
+    "player": "De'Von Achane",
+    "nfl_team": "Mia",
+    "position": "RB",
+    "offer_amount": 26
+  },
+  {
+    "manager": "Nick H",
+    "rank": 28,
+    "player": "Michael Pittman Jr.",
+    "nfl_team": "Ind",
+    "position": "WR",
+    "offer_amount": 26
+  },
+  {
+    "manager": "Nick H",
+    "rank": 43,
+    "player": "Alvin Kamara",
+    "nfl_team": "NO",
+    "position": "RB",
+    "offer_amount": 31
+  },
+  {
+    "manager": "Nick H",
+    "rank": 46,
+    "player": "Cooper Kupp",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 31
+  },
+  {
+    "manager": "Nick H",
+    "rank": 53,
+    "player": "DeVonta Smith",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 22
+  },
+  {
+    "manager": "Nick H",
+    "rank": 69,
+    "player": "Aaron Jones",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Nick H",
+    "rank": 75,
+    "player": "Dalton Kincaid",
+    "nfl_team": "Buf",
+    "position": "TE",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Nick H",
+    "rank": 79,
+    "player": "Raheem Mostert",
+    "nfl_team": "LV",
+    "position": "RB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Nick H",
+    "rank": 81,
+    "player": "Tyjae Spears",
+    "nfl_team": "Ten",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 86,
+    "player": "Christian Kirk",
+    "nfl_team": "Hou",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Nick H",
+    "rank": 91,
+    "player": "Kyler Murray",
+    "nfl_team": "Ari",
+    "position": "QB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 94,
+    "player": "Jayden Reed",
+    "nfl_team": "GB",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 114,
+    "player": "Dallas Goedert",
+    "nfl_team": "Phi",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 115,
+    "player": "Jameson Williams",
+    "nfl_team": "Det",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 124,
+    "player": "Brandon Aubrey",
+    "nfl_team": "Dal",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 134,
+    "player": "Jets D/ST",
+    "nfl_team": "NYJ",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 4,
+    "player": "Bijan Robinson",
+    "nfl_team": "Atl",
+    "position": "RB",
+    "offer_amount": 53
+  },
+  {
+    "manager": "Diego",
+    "rank": 9,
+    "player": "A.J. Brown",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 51
+  },
+  {
+    "manager": "Diego",
+    "rank": 21,
+    "player": "Josh Jacobs",
+    "nfl_team": "GB",
+    "position": "RB",
+    "offer_amount": 32
+  },
+  {
+    "manager": "Diego",
+    "rank": 22,
+    "player": "Malik Nabers",
+    "nfl_team": "NYG",
+    "position": "WR",
+    "offer_amount": 27
+  },
+  {
+    "manager": "Diego",
+    "rank": 50,
+    "player": "Jalen Hurts",
+    "nfl_team": "Phi",
+    "position": "QB",
+    "offer_amount": 20
+  },
+  {
+    "manager": "Diego",
+    "rank": 103,
+    "player": "Jake Ferguson",
+    "nfl_team": "Dal",
+    "position": "TE",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 104,
+    "player": "Zack Moss",
+    "nfl_team": "Cin",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 106,
+    "player": "Brian Thomas Jr.",
+    "nfl_team": "Jax",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 113,
+    "player": "Tyler Allgeier",
+    "nfl_team": "Atl",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 116,
+    "player": "Hollywood Brown",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 127,
+    "player": "Adonai Mitchell",
+    "nfl_team": "Ind",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 133,
+    "player": "Blake Corum",
+    "nfl_team": "LAR",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 143,
+    "player": "Caleb Williams",
+    "nfl_team": "Chi",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 151,
+    "player": "Brandin Cooks",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 158,
+    "player": "Dontayvion Wicks",
+    "nfl_team": "GB",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 163,
+    "player": "Younghoe Koo",
+    "nfl_team": "Atl",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 167,
+    "player": "Seahawks D/ST",
+    "nfl_team": "Sea",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 10,
+    "player": "Saquon Barkley",
+    "nfl_team": "Phi",
+    "position": "RB",
+    "offer_amount": 50
+  },
+  {
+    "manager": "Jordan",
+    "rank": 15,
+    "player": "Kyren Williams",
+    "nfl_team": "LAR",
+    "position": "RB",
+    "offer_amount": 38
+  },
+  {
+    "manager": "Jordan",
+    "rank": 29,
+    "player": "DJ Moore",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 19
+  },
+  {
+    "manager": "Jordan",
+    "rank": 31,
+    "player": "Josh Allen",
+    "nfl_team": "Buf",
+    "position": "QB",
+    "offer_amount": 24
+  },
+  {
+    "manager": "Jordan",
+    "rank": 39,
+    "player": "Xavier Worthy",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 11
+  },
+  {
+    "manager": "Jordan",
+    "rank": 48,
+    "player": "Sam LaPorta",
+    "nfl_team": "Det",
+    "position": "TE",
+    "offer_amount": 19
+  },
+  {
+    "manager": "Jordan",
+    "rank": 54,
+    "player": "Tank Dell",
+    "nfl_team": "Hou",
+    "position": "WR",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Jordan",
+    "rank": 59,
+    "player": "Terry McLaurin",
+    "nfl_team": "Wsh",
+    "position": "WR",
+    "offer_amount": 11
+  },
+  {
+    "manager": "Jordan",
+    "rank": 82,
+    "player": "Ladd McConkey",
+    "nfl_team": "LAC",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Jordan",
+    "rank": 85,
+    "player": "Brian Robinson Jr.",
+    "nfl_team": "Wsh",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 87,
+    "player": "David Montgomery",
+    "nfl_team": "Det",
+    "position": "RB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Jordan",
+    "rank": 92,
+    "player": "Brock Bowers",
+    "nfl_team": "LV",
+    "position": "TE",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 95,
+    "player": "Rome Odunze",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Jordan",
+    "rank": 125,
+    "player": "Jordan Love",
+    "nfl_team": "GB",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 135,
+    "player": "Gus Edwards",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 144,
+    "player": "Dolphins D/ST",
+    "nfl_team": "Mia",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 152,
+    "player": "Greg Zuerlein",
+    "nfl_team": "NYJ",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 2,
+    "player": "Garrett Wilson",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 44
+  },
+  {
+    "manager": "Nick J",
+    "rank": 6,
+    "player": "Kirk Cousins",
+    "nfl_team": "Atl",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 23,
+    "player": "Isiah Pacheco",
+    "nfl_team": "KC",
+    "position": "RB",
+    "offer_amount": 39
+  },
+  {
+    "manager": "Nick J",
+    "rank": 25,
+    "player": "Breece Hall",
+    "nfl_team": "NYJ",
+    "position": "RB",
+    "offer_amount": 62
+  },
+  {
+    "manager": "Nick J",
+    "rank": 45,
+    "player": "Rashee Rice",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Nick J",
+    "rank": 47,
+    "player": "DK Metcalf",
+    "nfl_team": "Pit",
+    "position": "WR",
+    "offer_amount": 28
+  },
+  {
+    "manager": "Nick J",
+    "rank": 71,
+    "player": "Najee Harris",
+    "nfl_team": "LAC",
+    "position": "RB",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Nick J",
+    "rank": 74,
+    "player": "Kyle Pitts",
+    "nfl_team": "Atl",
+    "position": "TE",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick J",
+    "rank": 96,
+    "player": "Ezekiel Elliott",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 105,
+    "player": "J.K. Dobbins",
+    "nfl_team": "LAC",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick J",
+    "rank": 126,
+    "player": "Darnell Mooney",
+    "nfl_team": "Atl",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 136,
+    "player": "DeAndre Hopkins",
+    "nfl_team": "Bal",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 145,
+    "player": "Romeo Doubs",
+    "nfl_team": "GB",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 153,
+    "player": "Curtis Samuel",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 159,
+    "player": "Chiefs D/ST",
+    "nfl_team": "KC",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 164,
+    "player": "Adam Thielen",
+    "nfl_team": "Car",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 168,
+    "player": "Cameron Dicker",
+    "nfl_team": "LAC",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 5,
+    "player": "Jonathan Taylor",
+    "nfl_team": "Ind",
+    "position": "RB",
+    "offer_amount": 46
+  },
+  {
+    "manager": "Luca",
+    "rank": 20,
+    "player": "Justin Jefferson",
+    "nfl_team": "Min",
+    "position": "WR",
+    "offer_amount": 60
+  },
+  {
+    "manager": "Luca",
+    "rank": 32,
+    "player": "Davante Adams",
+    "nfl_team": "LAR",
+    "position": "WR",
+    "offer_amount": 35
+  },
+  {
+    "manager": "Luca",
+    "rank": 33,
+    "player": "Rachaad White",
+    "nfl_team": "TB",
+    "position": "RB",
+    "offer_amount": 25
+  },
+  {
+    "manager": "Luca",
+    "rank": 68,
+    "player": "Dak Prescott",
+    "nfl_team": "Dal",
+    "position": "QB",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Luca",
+    "rank": 70,
+    "player": "Chris Godwin",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Luca",
+    "rank": 73,
+    "player": "Zamir White",
+    "nfl_team": "LV",
+    "position": "RB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Luca",
+    "rank": 80,
+    "player": "George Kittle",
+    "nfl_team": "SF",
+    "position": "TE",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 84,
+    "player": "Austin Ekeler",
+    "nfl_team": "Wsh",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 93,
+    "player": "Courtland Sutton",
+    "nfl_team": "Den",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 102,
+    "player": "Bucky Irving",
+    "nfl_team": "TB",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Luca",
+    "rank": 108,
+    "player": "Nick Chubb",
+    "nfl_team": "Cle",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Luca",
+    "rank": 111,
+    "player": "Mike Williams",
+    "nfl_team": "LAC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 121,
+    "player": "Jakobi Meyers",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 123,
+    "player": "Joshua Palmer",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 131,
+    "player": "Ravens D/ST",
+    "nfl_team": "Bal",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 141,
+    "player": "Justin Tucker",
+    "nfl_team": "Bal",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 3,
+    "player": "CeeDee Lamb",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 59
+  },
+  {
+    "manager": "Sammy",
+    "rank": 24,
+    "player": "Drake London",
+    "nfl_team": "Atl",
+    "position": "WR",
+    "offer_amount": 25
+  },
+  {
+    "manager": "Sammy",
+    "rank": 35,
+    "player": "James Cook",
+    "nfl_team": "Buf",
+    "position": "RB",
+    "offer_amount": 22
+  },
+  {
+    "manager": "Sammy",
+    "rank": 37,
+    "player": "Joe Mixon",
+    "nfl_team": "Hou",
+    "position": "RB",
+    "offer_amount": 20
+  },
+  {
+    "manager": "Sammy",
+    "rank": 49,
+    "player": "D'Andre Swift",
+    "nfl_team": "Chi",
+    "position": "RB",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Sammy",
+    "rank": 55,
+    "player": "Tee Higgins",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Sammy",
+    "rank": 56,
+    "player": "George Pickens",
+    "nfl_team": "Pit",
+    "position": "WR",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Sammy",
+    "rank": 57,
+    "player": "Diontae Johnson",
+    "nfl_team": "Bal",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Sammy",
+    "rank": 58,
+    "player": "Anthony Richardson",
+    "nfl_team": "Ind",
+    "position": "QB",
+    "offer_amount": 11
+  },
+  {
+    "manager": "Sammy",
+    "rank": 63,
+    "player": "Mark Andrews",
+    "nfl_team": "Bal",
+    "position": "TE",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Sammy",
+    "rank": 77,
+    "player": "James Conner",
+    "nfl_team": "Ari",
+    "position": "RB",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Sammy",
+    "rank": 88,
+    "player": "Jaylen Warren",
+    "nfl_team": "Pit",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 118,
+    "player": "Zach Charbonnet",
+    "nfl_team": "Sea",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 128,
+    "player": "Jayden Daniels",
+    "nfl_team": "Wsh",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 138,
+    "player": "Steelers D/ST",
+    "nfl_team": "Pit",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 147,
+    "player": "Dalton Schultz",
+    "nfl_team": "Hou",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 155,
+    "player": "Jake Elliott",
+    "nfl_team": "Phi",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 1,
+    "player": "Ja'Marr Chase",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 56
+  },
+  {
+    "manager": "Logan",
+    "rank": 7,
+    "player": "Jahmyr Gibbs",
+    "nfl_team": "Det",
+    "position": "RB",
+    "offer_amount": 43
+  },
+  {
+    "manager": "Logan",
+    "rank": 11,
+    "player": "Mike Evans",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 31
+  },
+  {
+    "manager": "Logan",
+    "rank": 40,
+    "player": "Brandon Aiyuk",
+    "nfl_team": "SF",
+    "position": "WR",
+    "offer_amount": 20
+  },
+  {
+    "manager": "Logan",
+    "rank": 51,
+    "player": "Evan Engram",
+    "nfl_team": "Den",
+    "position": "TE",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Logan",
+    "rank": 62,
+    "player": "Joe Burrow",
+    "nfl_team": "Cin",
+    "position": "QB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Logan",
+    "rank": 66,
+    "player": "Jaxon Smith-Njigba",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Logan",
+    "rank": 67,
+    "player": "Zay Flowers",
+    "nfl_team": "Bal",
+    "position": "WR",
+    "offer_amount": 18
+  },
+  {
+    "manager": "Logan",
+    "rank": 83,
+    "player": "Javonte Williams",
+    "nfl_team": "Dal",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Logan",
+    "rank": 90,
+    "player": "Devin Singletary",
+    "nfl_team": "NYG",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Logan",
+    "rank": 98,
+    "player": "Jerome Ford",
+    "nfl_team": "Cle",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Logan",
+    "rank": 107,
+    "player": "Jonathon Brooks",
+    "nfl_team": "Car",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Logan",
+    "rank": 117,
+    "player": "Ty Chandler",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 137,
+    "player": "Cowboys D/ST",
+    "nfl_team": "Dal",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 146,
+    "player": "Khalil Shakir",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 154,
+    "player": "Trey Benson",
+    "nfl_team": "Ari",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 160,
+    "player": "Evan McPherson",
+    "nfl_team": "Cin",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 8,
+    "player": "Christian McCaffrey",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 67
+  },
+  {
+    "manager": "Mike",
+    "rank": 12,
+    "player": "Marvin Harrison Jr.",
+    "nfl_team": "Ari",
+    "position": "WR",
+    "offer_amount": 36
+  },
+  {
+    "manager": "Mike",
+    "rank": 30,
+    "player": "Jaylen Waddle",
+    "nfl_team": "Mia",
+    "position": "WR",
+    "offer_amount": 23
+  },
+  {
+    "manager": "Mike",
+    "rank": 36,
+    "player": "Deebo Samuel Sr.",
+    "nfl_team": "Wsh",
+    "position": "WR",
+    "offer_amount": 34
+  },
+  {
+    "manager": "Mike",
+    "rank": 44,
+    "player": "Patrick Mahomes",
+    "nfl_team": "KC",
+    "position": "QB",
+    "offer_amount": 17
+  },
+  {
+    "manager": "Mike",
+    "rank": 65,
+    "player": "Rhamondre Stevenson",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Mike",
+    "rank": 72,
+    "player": "David Njoku",
+    "nfl_team": "Cle",
+    "position": "TE",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Mike",
+    "rank": 101,
+    "player": "Jordan Addison",
+    "nfl_team": "Min",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Mike",
+    "rank": 112,
+    "player": "Rico Dowdle",
+    "nfl_team": "Car",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Mike",
+    "rank": 122,
+    "player": "Gabe Davis",
+    "nfl_team": "Jax",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 132,
+    "player": "49ers D/ST",
+    "nfl_team": "SF",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 142,
+    "player": "Jake Moody",
+    "nfl_team": "SF",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 150,
+    "player": "Brock Purdy",
+    "nfl_team": "SF",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 157,
+    "player": "Khalil Herbert",
+    "nfl_team": "Ind",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 162,
+    "player": "Pat Freiermuth",
+    "nfl_team": "Pit",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 166,
+    "player": "Kyle Juszczyk",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 170,
+    "player": "Antonio Gibson",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 13,
+    "player": "Puka Nacua",
+    "nfl_team": "LAR",
+    "position": "WR",
+    "offer_amount": 39
+  },
+  {
+    "manager": "Adrian",
+    "rank": 16,
+    "player": "Tyreek Hill",
+    "nfl_team": "Mia",
+    "position": "WR",
+    "offer_amount": 70
+  },
+  {
+    "manager": "Adrian",
+    "rank": 27,
+    "player": "Derrick Henry",
+    "nfl_team": "Bal",
+    "position": "RB",
+    "offer_amount": 35
+  },
+  {
+    "manager": "Adrian",
+    "rank": 34,
+    "player": "Lamar Jackson",
+    "nfl_team": "Bal",
+    "position": "QB",
+    "offer_amount": 14
+  },
+  {
+    "manager": "Adrian",
+    "rank": 38,
+    "player": "Nico Collins",
+    "nfl_team": "Hou",
+    "position": "WR",
+    "offer_amount": 23
+  },
+  {
+    "manager": "Adrian",
+    "rank": 64,
+    "player": "Trey McBride",
+    "nfl_team": "Ari",
+    "position": "TE",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Adrian",
+    "rank": 76,
+    "player": "Christian Watson",
+    "nfl_team": "GB",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Adrian",
+    "rank": 100,
+    "player": "Chase Brown",
+    "nfl_team": "Cin",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 110,
+    "player": "Chuba Hubbard",
+    "nfl_team": "Car",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 120,
+    "player": "Tyler Lockett",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 130,
+    "player": "Jaleel McLaughlin",
+    "nfl_team": "Den",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 140,
+    "player": "T.J. Hockenson",
+    "nfl_team": "Min",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 149,
+    "player": "Saints D/ST",
+    "nfl_team": "NO",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 156,
+    "player": "Ka'imi Fairbairn",
+    "nfl_team": "Hou",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 161,
+    "player": "DeMario Douglas",
+    "nfl_team": "NE",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 165,
+    "player": "MarShawn Lloyd",
+    "nfl_team": "GB",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 169,
+    "player": "Rashid Shaheed",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 1
+  }
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,11 +75,12 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
 }
 
 function AppData() {
-  const [route, setRoute] = useState<'board' | 'analytics' | 'draft'>(() => window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.endsWith('/draft-rankings/2025') ? 'draft' : 'board')
+  const [route, setRoute] = useState<'board' | 'analytics' | 'draft'>(() => window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.match(/\/draft-rankings\/(2024|2025)$/) ? 'draft' : 'board')
+  const [draftSeason, setDraftSeason] = useState<2024 | 2025>(() => window.location.pathname.endsWith('/draft-rankings/2024') ? 2024 : 2025)
   const [manifest, setManifest] = useState<DataManifest>(emptyManifest)
   const [teams, setTeams] = useState<Record<string, TeamAsset>>({})
   const [rows, setRows] = useState<RankingRow[]>([])
-  const [draftRows, setDraftRows] = useState<DraftRankingRow[]>([])
+  const [draftRowsBySeason, setDraftRowsBySeason] = useState<Record<number, DraftRankingRow[]>>({})
   const [yahooProjections, setYahooProjections] = useState<YahooProjectionMap>({})
   const [sourceChecks, setSourceChecks] = useState<SourceCheckPayload | undefined>()
   const [selectedSeason, setSelectedSeason] = useState<number>(0)
@@ -92,7 +93,11 @@ function AppData() {
   const [retryKey, setRetryKey] = useState(0)
 
   useEffect(() => {
-    const handlePopState = () => setRoute(window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.endsWith('/draft-rankings/2025') ? 'draft' : 'board')
+    const handlePopState = () => {
+      const match = window.location.pathname.match(/\/draft-rankings\/(2024|2025)$/)
+      setRoute(window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : match ? 'draft' : 'board')
+      if (match) setDraftSeason(Number(match[1]) as 2024 | 2025)
+    }
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
   }, [])
@@ -113,12 +118,13 @@ function AppData() {
       fetchJson<DataManifest>('/data/manifest.json', controller.signal),
       fetchJson<Record<string, TeamAsset>>('/data/assets/espn_nfl_teams.json', controller.signal).catch(() => ({})),
       fetchJson<SourceCheckPayload>('/data/status/source_checks.json', controller.signal).catch(() => undefined),
+      fetchJson<DraftRankingRow[]>('/data/2024/draft-rankings.json', controller.signal),
       fetchJson<DraftRankingRow[]>('/data/2025/draft-rankings.json', controller.signal)
-    ]).then(([loadedManifest, loadedTeams, loadedChecks, loadedDraftRows]) => {
+    ]).then(([loadedManifest, loadedTeams, loadedChecks, loadedDraftRows2024, loadedDraftRows2025]) => {
       setManifest(loadedManifest)
       setTeams(loadedTeams)
       setSourceChecks(loadedChecks)
-      setDraftRows(loadedDraftRows)
+      setDraftRowsBySeason({ 2024: loadedDraftRows2024, 2025: loadedDraftRows2025 })
       const firstSeason = loadedManifest.seasons[0]
       const sharedDraft = readDraftShare(new URLSearchParams(window.location.search).get('draft'))
       let saved: { season?: number; source?: string; adjustedProfile?: string } = {}
@@ -184,7 +190,7 @@ function AppData() {
   if (error) return <ErrorState message={error} onRetry={() => { setRows([]); setRowsLoading(true); setHasLoadedRows(false); setRetryKey((current) => current + 1) }} />
   if (manifestLoading || !manifest.seasons.length || !selectedSource || !hasLoadedRows) return <LoadingState detail={manifestLoading ? undefined : `Loading ${selectedMeta?.label ?? 'the selected source'} rankings…`} />
 
-  if (route === 'draft') return <DraftRankingsPage rows={draftRows} onNavigate={navigate} />
+  if (route === 'draft') return <DraftRankingsPage season={draftSeason} rows={draftRowsBySeason[draftSeason] ?? []} onNavigate={navigate} />
 
   const displayedRows = applyAdjustedProfile(rows, selectedProfile?.id ?? 'full-ppr', selectedSource)
   return <RankingsDashboard manifest={manifest} rows={displayedRows} teams={teams} yahooProjections={yahooProjections} sourceChecks={sourceChecks} selectedSeason={selectedSeason} selectedSource={selectedSource} adjustedProfiles={adjustedProfiles} selectedAdjustedProfile={selectedProfile?.id ?? 'full-ppr'} onAdjustedProfile={setSelectedAdjustedProfile} onSeason={handleSeason} onSource={setSelectedSource} route={route} onNavigate={navigate} />

--- a/frontend/src/components/DraftRankingsPage.tsx
+++ b/frontend/src/components/DraftRankingsPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import type { DraftRankingRow } from '../types'
 
 type SortKey = 'rank' | 'player' | 'position' | 'offer_amount' | 'manager' | 'nfl_team'
-type Props = { rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
+type Props = { season: 2024 | 2025; rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
 
 const POSITION_ORDER = ['ALL', 'QB', 'RB', 'WR', 'TE', 'K', 'D/ST']
 const DRAFT_SIZE = 10
@@ -11,7 +11,7 @@ const STORAGE_KEY = 'rankingsdiff:auction-results:v1:2025'
 function rowId(row: DraftRankingRow): string { return `${row.player.toLowerCase()}|${row.nfl_team.toLowerCase()}` }
 function money(value: number): string { return `$${value}` }
 
-export function DraftRankingsPage({ rows, onNavigate }: Props) {
+export function DraftRankingsPage({ season, rows, onNavigate }: Props) {
   const [position, setPosition] = useState('ALL')
   const [search, setSearch] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('offer_amount')
@@ -19,7 +19,7 @@ export function DraftRankingsPage({ rows, onNavigate }: Props) {
   const [showUndrafted, setShowUndrafted] = useState(true)
   const [drafted, setDrafted] = useState<Set<string>>(() => {
     try {
-      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? 'null') as string[] | null
+      const saved = JSON.parse(localStorage.getItem(`${STORAGE_KEY}:${season}`) ?? 'null') as string[] | null
       return saved ? new Set(saved) : new Set(rows.map(rowId))
     } catch { return new Set(rows.map(rowId)) }
   })
@@ -29,7 +29,7 @@ export function DraftRankingsPage({ rows, onNavigate }: Props) {
       const next = new Set(current)
       const id = rowId(row)
       if (next.has(id)) next.delete(id); else next.add(id)
-      localStorage.setItem(STORAGE_KEY, JSON.stringify([...next]))
+      localStorage.setItem(`${STORAGE_KEY}:${season}`, JSON.stringify([...next]))
       return next
     })
   }
@@ -61,7 +61,7 @@ export function DraftRankingsPage({ rows, onNavigate }: Props) {
 
   return <main className="dashboard draft-rankings-page">
     <section className="hero hero--compact hero--editorial" aria-label="Draft rankings header">
-      <div className="hero__brand"><div className="loading-mark draft-rankings-mark" aria-hidden="true"><span>25</span></div><div><span className="eyebrow">Auction results</span><h1>2025 Draft</h1><p className="view-summary"><strong>{rows.length}</strong> players · <strong>{new Set(rows.map((row) => row.manager)).size}</strong> managers</p></div></div>
+      <div className="hero__brand"><div className="loading-mark draft-rankings-mark" aria-hidden="true"><span>{season}</span></div><div><span className="eyebrow">Auction results</span><h1>{season} Draft</h1><p className="view-summary"><strong>{rows.length}</strong> players · <strong>{new Set(rows.map((row) => row.manager)).size}</strong> managers</p></div></div>
       <div className="hero__context"><div className="hero__context-actions"><span>Draft rankings</span><button className="settings-icon-trigger" type="button" onClick={() => onNavigate('board')} aria-label="Back to rankings board">×</button></div><div className="hero__context-bottom"><button className="analytics-link" type="button" onClick={() => onNavigate('board')}>Rankings board</button><button className="analytics-link" type="button" onClick={() => onNavigate('analytics')}>Rankings diff</button></div></div>
     </section>
 

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -103,6 +103,13 @@ test('2025 auction rankings supports manager aliases, position sorting, and live
   await expect(page.getByRole('button', { name: 'Undrafted' }).first()).toBeVisible()
 })
 
+test('2024 auction rankings loads from its own direct route', async ({ page }) => {
+  await page.goto('./draft-rankings/2024')
+  await expect(page.getByRole('heading', { name: '2024 Draft' })).toBeVisible()
+  await expect(page.getByText('Christian McCaffrey · $67').first()).toBeVisible()
+  await expect(page.getByText('Mike', { exact: true }).first()).toBeVisible()
+})
+
 test('trend is off by default and can be shown and sorted', async ({ page }) => {
   await page.goto('./')
   await expect(page.getByRole('columnheader', { name: /regression/i })).toHaveCount(0)


### PR DESCRIPTION
## Summary
- Adds the 2024 auction draft dataset using manager aliases only.
- Supports `/draft-rankings/2024` alongside the existing 2025 route.
- Keeps drafted-state storage separate by season.

## Testing
- `asdf exec npm --prefix frontend run lint`
- `asdf exec npm --prefix frontend run test`
- `asdf exec npm --prefix frontend run build`
- Chromium direct-route test for 2024 passes.

## Release
- Bumps version to 1.66.3.