### PR TITLE
Add 2023 auction draft data

### DIFF
--- a/data/raw/2023/draft_rankings.csv
+++ b/data/raw/2023/draft_rankings.csv
@@ -1,0 +1,171 @@
+manager,rank,player,nfl_team,position,offer_amount
+Dane,5,A.J. Brown,Phi,WR,39
+Dane,22,DJ Moore,Chi,WR,13
+Dane,24,Patrick Mahomes,KC,QB,33
+Dane,32,Stefon Diggs,Buf,WR,51
+Dane,39,Alvin Kamara,NO,RB,12
+Dane,45,Amari Cooper,Cle,WR,21
+Dane,49,Isiah Pacheco,KC,RB,16
+Dane,64,George Kittle,SF,TE,6
+Dane,92,Jaxon Smith-Njigba,Sea,WR,1
+Dane,112,49ers D/ST,SF,D/ST,1
+Dane,122,Younghoe Koo,Atl,K,1
+Dane,132,Cole Kmet,Chi,TE,1
+Dane,141,Tyler Boyd,Cin,WR,1
+Dane,148,Jameson Williams,Det,WR,1
+Dane,155,Damien Harris,Buf,RB,1
+Dane,162,Geno Smith,Sea,QB,1
+Dane,168,Kenneth Gainwell,Phi,RB,1
+Nick H,15,Travis Kelce,KC,TE,55
+Nick H,28,Tee Higgins,Cin,WR,26
+Nick H,34,CeeDee Lamb,Dal,WR,46
+Nick H,41,Jahmyr Gibbs,Det,RB,21
+Nick H,59,DeVonta Smith,Phi,WR,24
+Nick H,61,James Cook,Buf,RB,9
+Nick H,76,Trevor Lawrence,Jax,QB,2
+Nick H,83,David Montgomery,Det,RB,6
+Nick H,108,JuJu Smith-Schuster,NE,WR,2
+Nick H,113,Daniel Carlson,LV,K,1
+Nick H,123,Allen Lazard,NYJ,WR,1
+Nick H,131,Adam Thielen,Car,WR,2
+Nick H,133,Ravens D/ST,Bal,D/ST,1
+Nick H,142,K.J. Osborn,NE,WR,1
+Nick H,149,Tyler Higbee,LAR,TE,1
+Nick H,156,Gus Edwards,LAC,RB,1
+Nick H,163,Hunter Renfrow,LV,WR,1
+Diego,26,DK Metcalf,Sea,WR,30
+Diego,29,Lamar Jackson,Bal,QB,21
+Diego,31,Rhamondre Stevenson,NE,RB,18
+Diego,42,Joe Mixon,Hou,RB,31
+Diego,43,Dameon Pierce,Hou,RB,13
+Diego,46,Calvin Ridley,Ten,WR,28
+Diego,55,Mike Williams,NYJ,WR,14
+Diego,65,Drake London,Atl,WR,9
+Diego,73,Cam Akers,Min,RB,6
+Diego,74,Christian Watson,GB,WR,13
+Diego,78,Dallas Goedert,Phi,TE,5
+Diego,82,Gabe Davis,Jax,WR,3
+Diego,98,Jordan Addison,Min,WR,4
+Diego,100,Justin Tucker,Bal,K,1
+Diego,110,Steelers D/ST,Pit,D/ST,1
+Diego,111,Brian Robinson Jr.,Wsh,RB,2
+Diego,130,Anthony Richardson,Ind,QB,1
+Jordan,1,Tony Pollard,Ten,RB,47
+Jordan,19,Garrett Wilson,NYJ,WR,45
+Jordan,23,Josh Allen,Buf,QB,30
+Jordan,35,Deebo Samuel,SF,WR,26
+Jordan,50,T.J. Hockenson,Min,TE,10
+Jordan,52,George Pickens,Pit,WR,5
+Jordan,58,Miles Sanders,Car,RB,12
+Jordan,69,DJ Chark Jr.,Car,WR,2
+Jordan,84,Christian Kirk,Jax,WR,5
+Jordan,86,Dalvin Cook,Bal,RB,6
+Jordan,88,Jahan Dotson,Wsh,WR,5
+Jordan,102,Jamaal Williams,NO,RB,2
+Jordan,121,Tyler Allgeier,Atl,RB,1
+Jordan,140,Quentin Johnston,LAC,WR,1
+Jordan,147,Dolphins D/ST,Mia,D/ST,1
+Jordan,154,Jaylen Warren,Pit,RB,1
+Jordan,161,Brett Maher,LAR,K,1
+Nick J,4,Ja'Marr Chase,Cin,WR,62
+Nick J,6,Cooper Kupp,LAR,WR,53
+Nick J,9,Evan Engram,Jax,TE,4
+Nick J,14,Derrick Henry,Bal,RB,49
+Nick J,57,Justin Herbert,LAC,QB,11
+Nick J,66,Mike Evans,TB,WR,7
+Nick J,79,Jerick McKinnon,KC,RB,1
+Nick J,81,Odell Beckham Jr.,FA,WR,2
+Nick J,99,Ezekiel Elliott,NE,RB,1
+Nick J,109,Rashaad Penny,Phi,RB,3
+Nick J,119,Eagles D/ST,Phi,D/ST,1
+Nick J,129,Graham Gano,NYG,K,1
+Nick J,139,Dak Prescott,Dal,QB,1
+Nick J,146,Kirk Cousins,Atl,QB,1
+Nick J,153,Daniel Jones,NYG,QB,1
+Nick J,160,Dalton Kincaid,Buf,TE,1
+Nick J,167,Chigoziem Okonkwo,Ten,TE,1
+Luca,7,Josh Jacobs,GB,RB,37
+Luca,13,Jonathan Taylor,Ind,RB,29
+Luca,25,Keenan Allen,Chi,WR,18
+Luca,33,Aaron Jones,Min,RB,19
+Luca,37,Jaylen Waddle,Mia,WR,35
+Luca,44,Kenneth Walker III,Sea,RB,15
+Luca,51,Mark Andrews,Bal,TE,17
+Luca,75,Tyler Lockett,Sea,WR,6
+Luca,80,Marquise Brown,KC,WR,5
+Luca,90,Deshaun Watson,Cle,QB,4
+Luca,91,Michael Pittman Jr.,Ind,WR,5
+Luca,96,AJ Dillon,GB,RB,3
+Luca,114,Treylon Burks,Ten,WR,2
+Luca,117,Bills D/ST,Buf,D/ST,2
+Luca,118,Aaron Rodgers,NYJ,QB,1
+Luca,128,Evan McPherson,Cin,K,1
+Luca,138,Raheem Mostert,Mia,RB,1
+Sammy,2,Justin Jefferson,Min,WR,63
+Sammy,3,Saquon Barkley,Phi,RB,45
+Sammy,21,Bijan Robinson,Atl,RB,54
+Sammy,67,Kyle Pitts,Atl,TE,4
+Sammy,68,J.K. Dobbins,Bal,RB,5
+Sammy,85,Justin Fields,Pit,QB,12
+Sammy,94,Brandin Cooks,Dal,WR,1
+Sammy,101,Zay Flowers,Bal,WR,5
+Sammy,104,Skky Moore,KC,WR,3
+Sammy,124,Darnell Mooney,Atl,WR,1
+Sammy,134,Samaje Perine,Den,RB,1
+Sammy,143,Elijah Moore,Cle,WR,1
+Sammy,150,Zach Ertz,Wsh,TE,1
+Sammy,157,Tank Bigsby,Jax,RB,1
+Sammy,164,Roschon Johnson,Chi,RB,1
+Sammy,169,Patriots D/ST,NE,D/ST,1
+Sammy,170,Jason Myers,Sea,K,1
+Logan,12,Darren Waller,NYG,TE,8
+Logan,18,Amon-Ra St. Brown,Det,WR,39
+Logan,20,Tyreek Hill,Mia,WR,54
+Logan,40,Najee Harris,Pit,RB,23
+Logan,47,Breece Hall,NYJ,RB,16
+Logan,54,Jerry Jeudy,Cle,WR,5
+Logan,56,Diontae Johnson,Car,WR,11
+Logan,70,Javonte Williams,Den,RB,5
+Logan,71,Alexander Mattison,LV,RB,12
+Logan,72,D'Andre Swift,Chi,RB,9
+Logan,77,Brandon Aiyuk,SF,WR,6
+Logan,93,Courtland Sutton,Den,WR,4
+Logan,106,Tua Tagovailoa,Mia,QB,1
+Logan,116,Elijah Mitchell,SF,RB,1
+Logan,120,Zach Charbonnet,Sea,RB,2
+Logan,126,Tyler Bass,Buf,K,1
+Logan,136,Jets D/ST,NYJ,D/ST,3
+Mike,8,Austin Ekeler,Wsh,RB,57
+Mike,10,Christian McCaffrey,SF,RB,65
+Mike,30,Jalen Hurts,Phi,QB,29
+Mike,48,Terry McLaurin,Wsh,WR,11
+Mike,53,DeAndre Hopkins,Ten,WR,13
+Mike,62,David Njoku,Cle,TE,4
+Mike,63,James Conner,Ari,RB,9
+Mike,89,Michael Thomas,NO,WR,3
+Mike,95,Antonio Gibson,NE,RB,1
+Mike,105,Jakobi Meyers,LV,WR,1
+Mike,115,Cowboys D/ST,Dal,D/ST,1
+Mike,125,Jeff Wilson Jr.,Mia,RB,1
+Mike,135,Jake Elliott,Phi,K,1
+Mike,144,Michael Gallup,Dal,WR,1
+Mike,151,Deuce Vaughn,Dal,RB,1
+Mike,158,Jared Goff,Det,QB,1
+Mike,165,Marquez Valdes-Scantling,KC,WR,1
+Adrian,11,Chris Olave,NO,WR,36
+Adrian,16,Davante Adams,LV,WR,44
+Adrian,17,Travis Etienne Jr.,Jax,RB,22
+Adrian,27,Nick Chubb,Cle,RB,47
+Adrian,36,Joe Burrow,Cin,QB,16
+Adrian,38,Chris Godwin,TB,WR,12
+Adrian,60,Rachaad White,TB,RB,10
+Adrian,87,Pat Freiermuth,Pit,TE,1
+Adrian,97,Harrison Butker,KC,K,1
+Adrian,103,Khalil Herbert,Chi,RB,4
+Adrian,107,Rondale Moore,Atl,WR,1
+Adrian,127,Saints D/ST,NO,D/ST,1
+Adrian,137,Dalton Schultz,Hou,TE,1
+Adrian,145,Nico Collins,Hou,WR,1
+Adrian,152,Devin Singletary,NYG,RB,1
+Adrian,159,Kadarius Toney,KC,WR,1
+Adrian,166,Parris Campbell,Phi,WR,1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.3",
+  "version": "1.66.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.66.3",
+      "version": "1.66.4",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.3",
+  "version": "1.66.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/public/data/2023/draft-rankings.json
+++ b/frontend/public/data/2023/draft-rankings.json
@@ -1,0 +1,1362 @@
+[
+  {
+    "manager": "Dane",
+    "rank": 5,
+    "player": "A.J. Brown",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 39
+  },
+  {
+    "manager": "Dane",
+    "rank": 22,
+    "player": "DJ Moore",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Dane",
+    "rank": 24,
+    "player": "Patrick Mahomes",
+    "nfl_team": "KC",
+    "position": "QB",
+    "offer_amount": 33
+  },
+  {
+    "manager": "Dane",
+    "rank": 32,
+    "player": "Stefon Diggs",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 51
+  },
+  {
+    "manager": "Dane",
+    "rank": 39,
+    "player": "Alvin Kamara",
+    "nfl_team": "NO",
+    "position": "RB",
+    "offer_amount": 12
+  },
+  {
+    "manager": "Dane",
+    "rank": 45,
+    "player": "Amari Cooper",
+    "nfl_team": "Cle",
+    "position": "WR",
+    "offer_amount": 21
+  },
+  {
+    "manager": "Dane",
+    "rank": 49,
+    "player": "Isiah Pacheco",
+    "nfl_team": "KC",
+    "position": "RB",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Dane",
+    "rank": 64,
+    "player": "George Kittle",
+    "nfl_team": "SF",
+    "position": "TE",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Dane",
+    "rank": 92,
+    "player": "Jaxon Smith-Njigba",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 112,
+    "player": "49ers D/ST",
+    "nfl_team": "SF",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 122,
+    "player": "Younghoe Koo",
+    "nfl_team": "Atl",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 132,
+    "player": "Cole Kmet",
+    "nfl_team": "Chi",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 141,
+    "player": "Tyler Boyd",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 148,
+    "player": "Jameson Williams",
+    "nfl_team": "Det",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 155,
+    "player": "Damien Harris",
+    "nfl_team": "Buf",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 162,
+    "player": "Geno Smith",
+    "nfl_team": "Sea",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 168,
+    "player": "Kenneth Gainwell",
+    "nfl_team": "Phi",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 15,
+    "player": "Travis Kelce",
+    "nfl_team": "KC",
+    "position": "TE",
+    "offer_amount": 55
+  },
+  {
+    "manager": "Nick H",
+    "rank": 28,
+    "player": "Tee Higgins",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 26
+  },
+  {
+    "manager": "Nick H",
+    "rank": 34,
+    "player": "CeeDee Lamb",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 46
+  },
+  {
+    "manager": "Nick H",
+    "rank": 41,
+    "player": "Jahmyr Gibbs",
+    "nfl_team": "Det",
+    "position": "RB",
+    "offer_amount": 21
+  },
+  {
+    "manager": "Nick H",
+    "rank": 59,
+    "player": "DeVonta Smith",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 24
+  },
+  {
+    "manager": "Nick H",
+    "rank": 61,
+    "player": "James Cook",
+    "nfl_team": "Buf",
+    "position": "RB",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Nick H",
+    "rank": 76,
+    "player": "Trevor Lawrence",
+    "nfl_team": "Jax",
+    "position": "QB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 83,
+    "player": "David Montgomery",
+    "nfl_team": "Det",
+    "position": "RB",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Nick H",
+    "rank": 108,
+    "player": "JuJu Smith-Schuster",
+    "nfl_team": "NE",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 113,
+    "player": "Daniel Carlson",
+    "nfl_team": "LV",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 123,
+    "player": "Allen Lazard",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 131,
+    "player": "Adam Thielen",
+    "nfl_team": "Car",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 133,
+    "player": "Ravens D/ST",
+    "nfl_team": "Bal",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 142,
+    "player": "K.J. Osborn",
+    "nfl_team": "NE",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 149,
+    "player": "Tyler Higbee",
+    "nfl_team": "LAR",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 156,
+    "player": "Gus Edwards",
+    "nfl_team": "LAC",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 163,
+    "player": "Hunter Renfrow",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 26,
+    "player": "DK Metcalf",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 30
+  },
+  {
+    "manager": "Diego",
+    "rank": 29,
+    "player": "Lamar Jackson",
+    "nfl_team": "Bal",
+    "position": "QB",
+    "offer_amount": 21
+  },
+  {
+    "manager": "Diego",
+    "rank": 31,
+    "player": "Rhamondre Stevenson",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 18
+  },
+  {
+    "manager": "Diego",
+    "rank": 42,
+    "player": "Joe Mixon",
+    "nfl_team": "Hou",
+    "position": "RB",
+    "offer_amount": 31
+  },
+  {
+    "manager": "Diego",
+    "rank": 43,
+    "player": "Dameon Pierce",
+    "nfl_team": "Hou",
+    "position": "RB",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Diego",
+    "rank": 46,
+    "player": "Calvin Ridley",
+    "nfl_team": "Ten",
+    "position": "WR",
+    "offer_amount": 28
+  },
+  {
+    "manager": "Diego",
+    "rank": 55,
+    "player": "Mike Williams",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 14
+  },
+  {
+    "manager": "Diego",
+    "rank": 65,
+    "player": "Drake London",
+    "nfl_team": "Atl",
+    "position": "WR",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Diego",
+    "rank": 73,
+    "player": "Cam Akers",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Diego",
+    "rank": 74,
+    "player": "Christian Watson",
+    "nfl_team": "GB",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Diego",
+    "rank": 78,
+    "player": "Dallas Goedert",
+    "nfl_team": "Phi",
+    "position": "TE",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Diego",
+    "rank": 82,
+    "player": "Gabe Davis",
+    "nfl_team": "Jax",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Diego",
+    "rank": 98,
+    "player": "Jordan Addison",
+    "nfl_team": "Min",
+    "position": "WR",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Diego",
+    "rank": 100,
+    "player": "Justin Tucker",
+    "nfl_team": "Bal",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 110,
+    "player": "Steelers D/ST",
+    "nfl_team": "Pit",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 111,
+    "player": "Brian Robinson Jr.",
+    "nfl_team": "Wsh",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 130,
+    "player": "Anthony Richardson",
+    "nfl_team": "Ind",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 1,
+    "player": "Tony Pollard",
+    "nfl_team": "Ten",
+    "position": "RB",
+    "offer_amount": 47
+  },
+  {
+    "manager": "Jordan",
+    "rank": 19,
+    "player": "Garrett Wilson",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 45
+  },
+  {
+    "manager": "Jordan",
+    "rank": 23,
+    "player": "Josh Allen",
+    "nfl_team": "Buf",
+    "position": "QB",
+    "offer_amount": 30
+  },
+  {
+    "manager": "Jordan",
+    "rank": 35,
+    "player": "Deebo Samuel",
+    "nfl_team": "SF",
+    "position": "WR",
+    "offer_amount": 26
+  },
+  {
+    "manager": "Jordan",
+    "rank": 50,
+    "player": "T.J. Hockenson",
+    "nfl_team": "Min",
+    "position": "TE",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Jordan",
+    "rank": 52,
+    "player": "George Pickens",
+    "nfl_team": "Pit",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Jordan",
+    "rank": 58,
+    "player": "Miles Sanders",
+    "nfl_team": "Car",
+    "position": "RB",
+    "offer_amount": 12
+  },
+  {
+    "manager": "Jordan",
+    "rank": 69,
+    "player": "DJ Chark Jr.",
+    "nfl_team": "Car",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 84,
+    "player": "Christian Kirk",
+    "nfl_team": "Jax",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Jordan",
+    "rank": 86,
+    "player": "Dalvin Cook",
+    "nfl_team": "Bal",
+    "position": "RB",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Jordan",
+    "rank": 88,
+    "player": "Jahan Dotson",
+    "nfl_team": "Wsh",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Jordan",
+    "rank": 102,
+    "player": "Jamaal Williams",
+    "nfl_team": "NO",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 121,
+    "player": "Tyler Allgeier",
+    "nfl_team": "Atl",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 140,
+    "player": "Quentin Johnston",
+    "nfl_team": "LAC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 147,
+    "player": "Dolphins D/ST",
+    "nfl_team": "Mia",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 154,
+    "player": "Jaylen Warren",
+    "nfl_team": "Pit",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 161,
+    "player": "Brett Maher",
+    "nfl_team": "LAR",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 4,
+    "player": "Ja'Marr Chase",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 62
+  },
+  {
+    "manager": "Nick J",
+    "rank": 6,
+    "player": "Cooper Kupp",
+    "nfl_team": "LAR",
+    "position": "WR",
+    "offer_amount": 53
+  },
+  {
+    "manager": "Nick J",
+    "rank": 9,
+    "player": "Evan Engram",
+    "nfl_team": "Jax",
+    "position": "TE",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Nick J",
+    "rank": 14,
+    "player": "Derrick Henry",
+    "nfl_team": "Bal",
+    "position": "RB",
+    "offer_amount": 49
+  },
+  {
+    "manager": "Nick J",
+    "rank": 57,
+    "player": "Justin Herbert",
+    "nfl_team": "LAC",
+    "position": "QB",
+    "offer_amount": 11
+  },
+  {
+    "manager": "Nick J",
+    "rank": 66,
+    "player": "Mike Evans",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Nick J",
+    "rank": 79,
+    "player": "Jerick McKinnon",
+    "nfl_team": "KC",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 81,
+    "player": "Odell Beckham Jr.",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick J",
+    "rank": 99,
+    "player": "Ezekiel Elliott",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 109,
+    "player": "Rashaad Penny",
+    "nfl_team": "Phi",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Nick J",
+    "rank": 119,
+    "player": "Eagles D/ST",
+    "nfl_team": "Phi",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 129,
+    "player": "Graham Gano",
+    "nfl_team": "NYG",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 139,
+    "player": "Dak Prescott",
+    "nfl_team": "Dal",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 146,
+    "player": "Kirk Cousins",
+    "nfl_team": "Atl",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 153,
+    "player": "Daniel Jones",
+    "nfl_team": "NYG",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 160,
+    "player": "Dalton Kincaid",
+    "nfl_team": "Buf",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 167,
+    "player": "Chigoziem Okonkwo",
+    "nfl_team": "Ten",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 7,
+    "player": "Josh Jacobs",
+    "nfl_team": "GB",
+    "position": "RB",
+    "offer_amount": 37
+  },
+  {
+    "manager": "Luca",
+    "rank": 13,
+    "player": "Jonathan Taylor",
+    "nfl_team": "Ind",
+    "position": "RB",
+    "offer_amount": 29
+  },
+  {
+    "manager": "Luca",
+    "rank": 25,
+    "player": "Keenan Allen",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 18
+  },
+  {
+    "manager": "Luca",
+    "rank": 33,
+    "player": "Aaron Jones",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 19
+  },
+  {
+    "manager": "Luca",
+    "rank": 37,
+    "player": "Jaylen Waddle",
+    "nfl_team": "Mia",
+    "position": "WR",
+    "offer_amount": 35
+  },
+  {
+    "manager": "Luca",
+    "rank": 44,
+    "player": "Kenneth Walker III",
+    "nfl_team": "Sea",
+    "position": "RB",
+    "offer_amount": 15
+  },
+  {
+    "manager": "Luca",
+    "rank": 51,
+    "player": "Mark Andrews",
+    "nfl_team": "Bal",
+    "position": "TE",
+    "offer_amount": 17
+  },
+  {
+    "manager": "Luca",
+    "rank": 75,
+    "player": "Tyler Lockett",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Luca",
+    "rank": 80,
+    "player": "Marquise Brown",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Luca",
+    "rank": 90,
+    "player": "Deshaun Watson",
+    "nfl_team": "Cle",
+    "position": "QB",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Luca",
+    "rank": 91,
+    "player": "Michael Pittman Jr.",
+    "nfl_team": "Ind",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Luca",
+    "rank": 96,
+    "player": "AJ Dillon",
+    "nfl_team": "GB",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Luca",
+    "rank": 114,
+    "player": "Treylon Burks",
+    "nfl_team": "Ten",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 117,
+    "player": "Bills D/ST",
+    "nfl_team": "Buf",
+    "position": "D/ST",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 118,
+    "player": "Aaron Rodgers",
+    "nfl_team": "NYJ",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 128,
+    "player": "Evan McPherson",
+    "nfl_team": "Cin",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 138,
+    "player": "Raheem Mostert",
+    "nfl_team": "Mia",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 2,
+    "player": "Justin Jefferson",
+    "nfl_team": "Min",
+    "position": "WR",
+    "offer_amount": 63
+  },
+  {
+    "manager": "Sammy",
+    "rank": 3,
+    "player": "Saquon Barkley",
+    "nfl_team": "Phi",
+    "position": "RB",
+    "offer_amount": 45
+  },
+  {
+    "manager": "Sammy",
+    "rank": 21,
+    "player": "Bijan Robinson",
+    "nfl_team": "Atl",
+    "position": "RB",
+    "offer_amount": 54
+  },
+  {
+    "manager": "Sammy",
+    "rank": 67,
+    "player": "Kyle Pitts",
+    "nfl_team": "Atl",
+    "position": "TE",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Sammy",
+    "rank": 68,
+    "player": "J.K. Dobbins",
+    "nfl_team": "Bal",
+    "position": "RB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Sammy",
+    "rank": 85,
+    "player": "Justin Fields",
+    "nfl_team": "Pit",
+    "position": "QB",
+    "offer_amount": 12
+  },
+  {
+    "manager": "Sammy",
+    "rank": 94,
+    "player": "Brandin Cooks",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 101,
+    "player": "Zay Flowers",
+    "nfl_team": "Bal",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Sammy",
+    "rank": 104,
+    "player": "Skky Moore",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Sammy",
+    "rank": 124,
+    "player": "Darnell Mooney",
+    "nfl_team": "Atl",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 134,
+    "player": "Samaje Perine",
+    "nfl_team": "Den",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 143,
+    "player": "Elijah Moore",
+    "nfl_team": "Cle",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 150,
+    "player": "Zach Ertz",
+    "nfl_team": "Wsh",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 157,
+    "player": "Tank Bigsby",
+    "nfl_team": "Jax",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 164,
+    "player": "Roschon Johnson",
+    "nfl_team": "Chi",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 169,
+    "player": "Patriots D/ST",
+    "nfl_team": "NE",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 170,
+    "player": "Jason Myers",
+    "nfl_team": "Sea",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 12,
+    "player": "Darren Waller",
+    "nfl_team": "NYG",
+    "position": "TE",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Logan",
+    "rank": 18,
+    "player": "Amon-Ra St. Brown",
+    "nfl_team": "Det",
+    "position": "WR",
+    "offer_amount": 39
+  },
+  {
+    "manager": "Logan",
+    "rank": 20,
+    "player": "Tyreek Hill",
+    "nfl_team": "Mia",
+    "position": "WR",
+    "offer_amount": 54
+  },
+  {
+    "manager": "Logan",
+    "rank": 40,
+    "player": "Najee Harris",
+    "nfl_team": "Pit",
+    "position": "RB",
+    "offer_amount": 23
+  },
+  {
+    "manager": "Logan",
+    "rank": 47,
+    "player": "Breece Hall",
+    "nfl_team": "NYJ",
+    "position": "RB",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Logan",
+    "rank": 54,
+    "player": "Jerry Jeudy",
+    "nfl_team": "Cle",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Logan",
+    "rank": 56,
+    "player": "Diontae Johnson",
+    "nfl_team": "Car",
+    "position": "WR",
+    "offer_amount": 11
+  },
+  {
+    "manager": "Logan",
+    "rank": 70,
+    "player": "Javonte Williams",
+    "nfl_team": "Den",
+    "position": "RB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Logan",
+    "rank": 71,
+    "player": "Alexander Mattison",
+    "nfl_team": "LV",
+    "position": "RB",
+    "offer_amount": 12
+  },
+  {
+    "manager": "Logan",
+    "rank": 72,
+    "player": "D'Andre Swift",
+    "nfl_team": "Chi",
+    "position": "RB",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Logan",
+    "rank": 77,
+    "player": "Brandon Aiyuk",
+    "nfl_team": "SF",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Logan",
+    "rank": 93,
+    "player": "Courtland Sutton",
+    "nfl_team": "Den",
+    "position": "WR",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Logan",
+    "rank": 106,
+    "player": "Tua Tagovailoa",
+    "nfl_team": "Mia",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 116,
+    "player": "Elijah Mitchell",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 120,
+    "player": "Zach Charbonnet",
+    "nfl_team": "Sea",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Logan",
+    "rank": 126,
+    "player": "Tyler Bass",
+    "nfl_team": "Buf",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 136,
+    "player": "Jets D/ST",
+    "nfl_team": "NYJ",
+    "position": "D/ST",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Mike",
+    "rank": 8,
+    "player": "Austin Ekeler",
+    "nfl_team": "Wsh",
+    "position": "RB",
+    "offer_amount": 57
+  },
+  {
+    "manager": "Mike",
+    "rank": 10,
+    "player": "Christian McCaffrey",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 65
+  },
+  {
+    "manager": "Mike",
+    "rank": 30,
+    "player": "Jalen Hurts",
+    "nfl_team": "Phi",
+    "position": "QB",
+    "offer_amount": 29
+  },
+  {
+    "manager": "Mike",
+    "rank": 48,
+    "player": "Terry McLaurin",
+    "nfl_team": "Wsh",
+    "position": "WR",
+    "offer_amount": 11
+  },
+  {
+    "manager": "Mike",
+    "rank": 53,
+    "player": "DeAndre Hopkins",
+    "nfl_team": "Ten",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Mike",
+    "rank": 62,
+    "player": "David Njoku",
+    "nfl_team": "Cle",
+    "position": "TE",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Mike",
+    "rank": 63,
+    "player": "James Conner",
+    "nfl_team": "Ari",
+    "position": "RB",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Mike",
+    "rank": 89,
+    "player": "Michael Thomas",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Mike",
+    "rank": 95,
+    "player": "Antonio Gibson",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 105,
+    "player": "Jakobi Meyers",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 115,
+    "player": "Cowboys D/ST",
+    "nfl_team": "Dal",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 125,
+    "player": "Jeff Wilson Jr.",
+    "nfl_team": "Mia",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 135,
+    "player": "Jake Elliott",
+    "nfl_team": "Phi",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 144,
+    "player": "Michael Gallup",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 151,
+    "player": "Deuce Vaughn",
+    "nfl_team": "Dal",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 158,
+    "player": "Jared Goff",
+    "nfl_team": "Det",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 165,
+    "player": "Marquez Valdes-Scantling",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 11,
+    "player": "Chris Olave",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 36
+  },
+  {
+    "manager": "Adrian",
+    "rank": 16,
+    "player": "Davante Adams",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 44
+  },
+  {
+    "manager": "Adrian",
+    "rank": 17,
+    "player": "Travis Etienne Jr.",
+    "nfl_team": "Jax",
+    "position": "RB",
+    "offer_amount": 22
+  },
+  {
+    "manager": "Adrian",
+    "rank": 27,
+    "player": "Nick Chubb",
+    "nfl_team": "Cle",
+    "position": "RB",
+    "offer_amount": 47
+  },
+  {
+    "manager": "Adrian",
+    "rank": 36,
+    "player": "Joe Burrow",
+    "nfl_team": "Cin",
+    "position": "QB",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Adrian",
+    "rank": 38,
+    "player": "Chris Godwin",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 12
+  },
+  {
+    "manager": "Adrian",
+    "rank": 60,
+    "player": "Rachaad White",
+    "nfl_team": "TB",
+    "position": "RB",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Adrian",
+    "rank": 87,
+    "player": "Pat Freiermuth",
+    "nfl_team": "Pit",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 97,
+    "player": "Harrison Butker",
+    "nfl_team": "KC",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 103,
+    "player": "Khalil Herbert",
+    "nfl_team": "Chi",
+    "position": "RB",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Adrian",
+    "rank": 107,
+    "player": "Rondale Moore",
+    "nfl_team": "Atl",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 127,
+    "player": "Saints D/ST",
+    "nfl_team": "NO",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 137,
+    "player": "Dalton Schultz",
+    "nfl_team": "Hou",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 145,
+    "player": "Nico Collins",
+    "nfl_team": "Hou",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 152,
+    "player": "Devin Singletary",
+    "nfl_team": "NYG",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 159,
+    "player": "Kadarius Toney",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 166,
+    "player": "Parris Campbell",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 1
+  }
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,8 +75,8 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
 }
 
 function AppData() {
-  const [route, setRoute] = useState<'board' | 'analytics' | 'draft'>(() => window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.match(/\/draft-rankings\/(2024|2025)$/) ? 'draft' : 'board')
-  const [draftSeason, setDraftSeason] = useState<2024 | 2025>(() => window.location.pathname.endsWith('/draft-rankings/2024') ? 2024 : 2025)
+  const [route, setRoute] = useState<'board' | 'analytics' | 'draft'>(() => window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.match(/\/draft-rankings\/(2023|2024|2025)$/) ? 'draft' : 'board')
+  const [draftSeason, setDraftSeason] = useState<2023 | 2024 | 2025>(() => window.location.pathname.endsWith('/draft-rankings/2023') ? 2023 : window.location.pathname.endsWith('/draft-rankings/2024') ? 2024 : 2025)
   const [manifest, setManifest] = useState<DataManifest>(emptyManifest)
   const [teams, setTeams] = useState<Record<string, TeamAsset>>({})
   const [rows, setRows] = useState<RankingRow[]>([])
@@ -94,9 +94,9 @@ function AppData() {
 
   useEffect(() => {
     const handlePopState = () => {
-      const match = window.location.pathname.match(/\/draft-rankings\/(2024|2025)$/)
+      const match = window.location.pathname.match(/\/draft-rankings\/(2023|2024|2025)$/)
       setRoute(window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : match ? 'draft' : 'board')
-      if (match) setDraftSeason(Number(match[1]) as 2024 | 2025)
+      if (match) setDraftSeason(Number(match[1]) as 2023 | 2024 | 2025)
     }
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
@@ -118,13 +118,14 @@ function AppData() {
       fetchJson<DataManifest>('/data/manifest.json', controller.signal),
       fetchJson<Record<string, TeamAsset>>('/data/assets/espn_nfl_teams.json', controller.signal).catch(() => ({})),
       fetchJson<SourceCheckPayload>('/data/status/source_checks.json', controller.signal).catch(() => undefined),
+      fetchJson<DraftRankingRow[]>('/data/2023/draft-rankings.json', controller.signal),
       fetchJson<DraftRankingRow[]>('/data/2024/draft-rankings.json', controller.signal),
       fetchJson<DraftRankingRow[]>('/data/2025/draft-rankings.json', controller.signal)
-    ]).then(([loadedManifest, loadedTeams, loadedChecks, loadedDraftRows2024, loadedDraftRows2025]) => {
+    ]).then(([loadedManifest, loadedTeams, loadedChecks, loadedDraftRows2023, loadedDraftRows2024, loadedDraftRows2025]) => {
       setManifest(loadedManifest)
       setTeams(loadedTeams)
       setSourceChecks(loadedChecks)
-      setDraftRowsBySeason({ 2024: loadedDraftRows2024, 2025: loadedDraftRows2025 })
+      setDraftRowsBySeason({ 2023: loadedDraftRows2023, 2024: loadedDraftRows2024, 2025: loadedDraftRows2025 })
       const firstSeason = loadedManifest.seasons[0]
       const sharedDraft = readDraftShare(new URLSearchParams(window.location.search).get('draft'))
       let saved: { season?: number; source?: string; adjustedProfile?: string } = {}

--- a/frontend/src/components/DraftRankingsPage.tsx
+++ b/frontend/src/components/DraftRankingsPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import type { DraftRankingRow } from '../types'
 
 type SortKey = 'rank' | 'player' | 'position' | 'offer_amount' | 'manager' | 'nfl_team'
-type Props = { season: 2024 | 2025; rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
+type Props = { season: 2023 | 2024 | 2025; rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
 
 const POSITION_ORDER = ['ALL', 'QB', 'RB', 'WR', 'TE', 'K', 'D/ST']
 const DRAFT_SIZE = 10

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -110,6 +110,13 @@ test('2024 auction rankings loads from its own direct route', async ({ page }) =
   await expect(page.getByText('Mike', { exact: true }).first()).toBeVisible()
 })
 
+test('2023 auction rankings loads from its own direct route', async ({ page }) => {
+  await page.goto('./draft-rankings/2023')
+  await expect(page.getByRole('heading', { name: '2023 Draft' })).toBeVisible()
+  await expect(page.getByText('Justin Jefferson · $63').first()).toBeVisible()
+  await expect(page.getByText('Sammy', { exact: true }).first()).toBeVisible()
+})
+
 test('trend is off by default and can be shown and sorted', async ({ page }) => {
   await page.goto('./')
   await expect(page.getByRole('columnheader', { name: /regression/i })).toHaveCount(0)


### PR DESCRIPTION
## Summary
- Adds the 2023 auction draft dataset using manager aliases only.
- Supports `/draft-rankings/2023` alongside 2024 and 2025.
- Keeps drafted-state storage separate by season.

## Testing
- `asdf exec npm --prefix frontend run lint`
- `asdf exec npm --prefix frontend run test`
- `asdf exec npm --prefix frontend run build`
- Chromium direct-route test for 2023 passes.

## Release
- Bumps version to 1.66.4.