### PR TITLE
Add 2022 auction draft data

### DIFF
--- a/data/raw/2022/draft_rankings.csv
+++ b/data/raw/2022/draft_rankings.csv
@@ -1,0 +1,171 @@
+manager,rank,player,nfl_team,position,offer_amount
+Dane,11,Christian McCaffrey,SF,RB,65
+Dane,15,Tyreek Hill,Mia,WR,47
+Dane,18,Najee Harris,Pit,RB,61
+Dane,57,Lamar Jackson,Bal,QB,8
+Dane,73,Allen Lazard,NYJ,WR,6
+Dane,98,Justin Tucker,Bal,K,2
+Dane,103,Dawson Knox,Buf,TE,1
+Dane,113,Tyler Boyd,Cin,WR,1
+Dane,122,Raheem Mostert,Mia,RB,1
+Dane,131,Marvin Jones Jr.,Jax,WR,1
+Dane,140,DJ Chark,Det,WR,1
+Dane,148,Colts D/ST,Ind,D/ST,1
+Dane,156,Trevor Lawrence,Jax,QB,1
+Dane,163,Noah Fant,Sea,TE,1
+Dane,167,Kenneth Gainwell,Phi,RB,1
+Dane,169,Khalil Herbert,Chi,RB,1
+Dane,170,Joshua Palmer,LAC,WR,1
+Nick H,7,Justin Jefferson,Min,WR,52
+Nick H,9,Joe Mixon,Cin,RB,46
+Nick H,33,T.J. Hockenson,Min,TE,8
+Nick H,34,Javonte Williams,Den,RB,38
+Nick H,38,Cam Akers,LAR,RB,27
+Nick H,52,Diontae Johnson,Pit,WR,16
+Nick H,85,Kareem Hunt,Cle,RB,2
+Nick H,87,Russell Wilson,Den,QB,2
+Nick H,90,Rashod Bateman,Bal,WR,1
+Nick H,100,Dallas Goedert,Phi,TE,1
+Nick H,110,Tom Brady,TB,QB,1
+Nick H,119,Garrett Wilson,NYJ,WR,1
+Nick H,128,Trey Lance,SF,QB,1
+Nick H,137,Robbie Anderson,FA,WR,1
+Nick H,145,Darrell Henderson Jr.,FA,RB,1
+Nick H,153,Steelers D/ST,Pit,D/ST,1
+Nick H,161,Matt Prater,Ari,K,1
+Diego,20,Mark Andrews,Bal,TE,35
+Diego,24,A.J. Brown,Phi,WR,25
+Diego,30,Saquon Barkley,NYG,RB,36
+Diego,35,Mike Williams,LAC,WR,23
+Diego,40,DK Metcalf,Sea,WR,13
+Diego,43,Justin Herbert,LAC,QB,15
+Diego,44,Courtland Sutton,Den,WR,16
+Diego,58,Tee Higgins,Cin,WR,20
+Diego,75,DeVonta Smith,Phi,WR,2
+Diego,76,Bills D/ST,Buf,D/ST,1
+Diego,78,Chase Edmonds,TB,RB,4
+Diego,82,Allen Robinson II,LAR,WR,4
+Diego,96,AJ Dillon,GB,RB,1
+Diego,106,Damien Harris,Buf,RB,1
+Diego,116,Kadarius Toney,KC,WR,1
+Diego,125,Michael Carter,NYJ,RB,1
+Diego,134,Daniel Carlson,LV,K,1
+Jordan,13,Nick Chubb,Cle,RB,36
+Jordan,16,Mike Evans,TB,WR,29
+Jordan,23,George Kittle,SF,TE,19
+Jordan,26,Kyle Pitts,Atl,TE,23
+Jordan,41,Josh Allen,Buf,QB,26
+Jordan,45,Gabe Davis,Buf,WR,15
+Jordan,48,Jerry Jeudy,Den,WR,13
+Jordan,62,Darnell Mooney,Chi,WR,10
+Jordan,63,Tyler Lockett,Sea,WR,3
+Jordan,65,Amon-Ra St. Brown,Det,WR,8
+Jordan,71,Clyde Edwards-Helaire,KC,RB,6
+Jordan,81,DeAndre Hopkins,Ari,WR,2
+Jordan,88,Rhamondre Stevenson,NE,RB,3
+Jordan,93,Cordarrelle Patterson,Atl,RB,2
+Jordan,97,Brandon Aiyuk,SF,WR,2
+Jordan,99,49ers D/ST,SF,D/ST,2
+Jordan,108,Matt Gay,Ind,K,1
+Nick J,1,Darren Waller,NYG,TE,10
+Nick J,3,Cooper Kupp,LAR,WR,44
+Nick J,17,Ja'Marr Chase,Cin,WR,55
+Nick J,21,Aaron Jones,GB,RB,49
+Nick J,50,Patrick Mahomes,KC,QB,14
+Nick J,55,Michael Thomas,NO,WR,6
+Nick J,60,JuJu Smith-Schuster,NE,WR,10
+Nick J,72,Devin Singletary,Hou,RB,3
+Nick J,91,Marquez Valdes-Scantling,KC,WR,1
+Nick J,101,Harrison Butker,KC,K,1
+Nick J,111,James Robinson,NE,RB,1
+Nick J,120,Kirk Cousins,Min,QB,1
+Nick J,129,Russell Gage,TB,WR,1
+Nick J,138,Jarvis Landry,NO,WR,1
+Nick J,146,Deshaun Watson,Cle,QB,1
+Nick J,154,Derek Carr,NO,QB,1
+Nick J,162,Dolphins D/ST,Mia,D/ST,1
+Luca,10,Derrick Henry,Ten,RB,65
+Luca,27,Stefon Diggs,Buf,WR,49
+Luca,28,CeeDee Lamb,Dal,WR,40
+Luca,37,Terry McLaurin,Wsh,WR,23
+Luca,56,Miles Sanders,Car,RB,6
+Luca,66,Jalen Hurts,Phi,QB,2
+Luca,74,Aaron Rodgers,GB,QB,2
+Luca,80,Antonio Gibson,Wsh,RB,4
+Luca,95,Tony Pollard,Dal,RB,1
+Luca,105,Buccaneers D/ST,TB,D/ST,1
+Luca,115,Nyheim Hines,Buf,RB,1
+Luca,124,Pat Freiermuth,Pit,TE,1
+Luca,133,Skky Moore,KC,WR,1
+Luca,142,Mike Gesicki,NE,TE,1
+Luca,150,Michael Gallup,Dal,WR,1
+Luca,158,Brandon McManus,Den,K,1
+Luca,165,Kenny Golladay,FA,WR,1
+Sammy,5,Alvin Kamara,NO,RB,43
+Sammy,25,Leonard Fournette,FA,RB,39
+Sammy,32,Elijah Mitchell,SF,RB,19
+Sammy,36,Jaylen Waddle,Mia,WR,21
+Sammy,42,James Conner,Ari,RB,33
+Sammy,47,Brandin Cooks,Dal,WR,16
+Sammy,59,Kyler Murray,Ari,QB,5
+Sammy,67,David Montgomery,Det,RB,14
+Sammy,86,Christian Kirk,Jax,WR,2
+Sammy,92,Elijah Moore,NYJ,WR,1
+Sammy,102,Robert Woods,FA,WR,1
+Sammy,112,Rashaad Penny,Phi,RB,1
+Sammy,121,Cole Kmet,Chi,TE,1
+Sammy,130,Cowboys D/ST,Dal,D/ST,1
+Sammy,139,Kenneth Walker III,Sea,RB,1
+Sammy,147,Chargers D/ST,LAC,D/ST,1
+Sammy,155,Nick Folk,NE,K,1
+Logan,4,Dalvin Cook,Min,RB,47
+Logan,6,D'Andre Swift,Det,RB,41
+Logan,8,Jonathan Taylor,Ind,RB,65
+Logan,46,Breece Hall,NYJ,RB,16
+Logan,68,Chris Godwin,TB,WR,8
+Logan,70,Marquise Brown,Ari,WR,7
+Logan,77,Dameon Pierce,Hou,RB,5
+Logan,79,Drake London,Atl,WR,2
+Logan,107,Matthew Stafford,LAR,QB,1
+Logan,117,Chase Claypool,Chi,WR,1
+Logan,126,James Cook,Buf,RB,1
+Logan,135,Rams D/ST,LAR,D/ST,1
+Logan,143,George Pickens,Pit,WR,1
+Logan,151,David Njoku,Cle,TE,1
+Logan,159,Isaiah McKenzie,FA,WR,1
+Logan,166,Tyron Davis-Price,SF,RB,1
+Logan,168,Robbie Gould,SF,K,1
+Mike,14,Travis Kelce,KC,TE,38
+Mike,19,Keenan Allen,LAC,WR,32
+Mike,22,Davante Adams,LV,WR,60
+Mike,31,Ezekiel Elliott,FA,RB,26
+Mike,51,J.K. Dobbins,Bal,RB,8
+Mike,53,Amari Cooper,Cle,WR,9
+Mike,61,Adam Thielen,FA,WR,12
+Mike,64,Hunter Renfrow,LV,WR,5
+Mike,83,Dalton Schultz,Hou,TE,2
+Mike,89,Dak Prescott,Dal,QB,1
+Mike,109,Chris Olave,NO,WR,1
+Mike,118,Tyler Bass,Buf,K,1
+Mike,127,Saints D/ST,NO,D/ST,1
+Mike,136,Alexander Mattison,Min,RB,1
+Mike,144,Julio Jones,TB,WR,1
+Mike,152,Jamaal Williams,NO,RB,1
+Mike,160,Mecole Hardman,KC,WR,1
+Adrian,2,Deebo Samuel,SF,WR,39
+Adrian,12,Austin Ekeler,LAC,RB,63
+Adrian,29,Michael Pittman Jr.,Ind,WR,34
+Adrian,39,Travis Etienne Jr.,Jax,RB,22
+Adrian,49,Josh Jacobs,LV,RB,18
+Adrian,54,Evan McPherson,Cin,K,1
+Adrian,69,DJ Moore,Chi,WR,13
+Adrian,84,Packers D/ST,GB,D/ST,1
+Adrian,94,Joe Burrow,Cin,QB,1
+Adrian,104,Zach Ertz,Ari,TE,1
+Adrian,114,Melvin Gordon III,FA,RB,1
+Adrian,123,Hunter Henry,NE,TE,1
+Adrian,132,Jakobi Meyers,LV,WR,1
+Adrian,141,Ravens D/ST,Bal,D/ST,1
+Adrian,149,J.D. McKissic,FA,RB,1
+Adrian,157,Treylon Burks,Ten,WR,1
+Adrian,164,Justin Fields,Chi,QB,1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.4",
+  "version": "1.66.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.66.4",
+      "version": "1.66.5",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.4",
+  "version": "1.66.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/public/data/2022/draft-rankings.json
+++ b/frontend/public/data/2022/draft-rankings.json
@@ -1,0 +1,1362 @@
+[
+  {
+    "manager": "Dane",
+    "rank": 11,
+    "player": "Christian McCaffrey",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 65
+  },
+  {
+    "manager": "Dane",
+    "rank": 15,
+    "player": "Tyreek Hill",
+    "nfl_team": "Mia",
+    "position": "WR",
+    "offer_amount": 47
+  },
+  {
+    "manager": "Dane",
+    "rank": 18,
+    "player": "Najee Harris",
+    "nfl_team": "Pit",
+    "position": "RB",
+    "offer_amount": 61
+  },
+  {
+    "manager": "Dane",
+    "rank": 57,
+    "player": "Lamar Jackson",
+    "nfl_team": "Bal",
+    "position": "QB",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Dane",
+    "rank": 73,
+    "player": "Allen Lazard",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Dane",
+    "rank": 98,
+    "player": "Justin Tucker",
+    "nfl_team": "Bal",
+    "position": "K",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Dane",
+    "rank": 103,
+    "player": "Dawson Knox",
+    "nfl_team": "Buf",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 113,
+    "player": "Tyler Boyd",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 122,
+    "player": "Raheem Mostert",
+    "nfl_team": "Mia",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 131,
+    "player": "Marvin Jones Jr.",
+    "nfl_team": "Jax",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 140,
+    "player": "DJ Chark",
+    "nfl_team": "Det",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 148,
+    "player": "Colts D/ST",
+    "nfl_team": "Ind",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 156,
+    "player": "Trevor Lawrence",
+    "nfl_team": "Jax",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 163,
+    "player": "Noah Fant",
+    "nfl_team": "Sea",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 167,
+    "player": "Kenneth Gainwell",
+    "nfl_team": "Phi",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 169,
+    "player": "Khalil Herbert",
+    "nfl_team": "Chi",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Dane",
+    "rank": 170,
+    "player": "Joshua Palmer",
+    "nfl_team": "LAC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 7,
+    "player": "Justin Jefferson",
+    "nfl_team": "Min",
+    "position": "WR",
+    "offer_amount": 52
+  },
+  {
+    "manager": "Nick H",
+    "rank": 9,
+    "player": "Joe Mixon",
+    "nfl_team": "Cin",
+    "position": "RB",
+    "offer_amount": 46
+  },
+  {
+    "manager": "Nick H",
+    "rank": 33,
+    "player": "T.J. Hockenson",
+    "nfl_team": "Min",
+    "position": "TE",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Nick H",
+    "rank": 34,
+    "player": "Javonte Williams",
+    "nfl_team": "Den",
+    "position": "RB",
+    "offer_amount": 38
+  },
+  {
+    "manager": "Nick H",
+    "rank": 38,
+    "player": "Cam Akers",
+    "nfl_team": "LAR",
+    "position": "RB",
+    "offer_amount": 27
+  },
+  {
+    "manager": "Nick H",
+    "rank": 52,
+    "player": "Diontae Johnson",
+    "nfl_team": "Pit",
+    "position": "WR",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Nick H",
+    "rank": 85,
+    "player": "Kareem Hunt",
+    "nfl_team": "Cle",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 87,
+    "player": "Russell Wilson",
+    "nfl_team": "Den",
+    "position": "QB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Nick H",
+    "rank": 90,
+    "player": "Rashod Bateman",
+    "nfl_team": "Bal",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 100,
+    "player": "Dallas Goedert",
+    "nfl_team": "Phi",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 110,
+    "player": "Tom Brady",
+    "nfl_team": "TB",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 119,
+    "player": "Garrett Wilson",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 128,
+    "player": "Trey Lance",
+    "nfl_team": "SF",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 137,
+    "player": "Robbie Anderson",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 145,
+    "player": "Darrell Henderson Jr.",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 153,
+    "player": "Steelers D/ST",
+    "nfl_team": "Pit",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick H",
+    "rank": 161,
+    "player": "Matt Prater",
+    "nfl_team": "Ari",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 20,
+    "player": "Mark Andrews",
+    "nfl_team": "Bal",
+    "position": "TE",
+    "offer_amount": 35
+  },
+  {
+    "manager": "Diego",
+    "rank": 24,
+    "player": "A.J. Brown",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 25
+  },
+  {
+    "manager": "Diego",
+    "rank": 30,
+    "player": "Saquon Barkley",
+    "nfl_team": "NYG",
+    "position": "RB",
+    "offer_amount": 36
+  },
+  {
+    "manager": "Diego",
+    "rank": 35,
+    "player": "Mike Williams",
+    "nfl_team": "LAC",
+    "position": "WR",
+    "offer_amount": 23
+  },
+  {
+    "manager": "Diego",
+    "rank": 40,
+    "player": "DK Metcalf",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Diego",
+    "rank": 43,
+    "player": "Justin Herbert",
+    "nfl_team": "LAC",
+    "position": "QB",
+    "offer_amount": 15
+  },
+  {
+    "manager": "Diego",
+    "rank": 44,
+    "player": "Courtland Sutton",
+    "nfl_team": "Den",
+    "position": "WR",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Diego",
+    "rank": 58,
+    "player": "Tee Higgins",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 20
+  },
+  {
+    "manager": "Diego",
+    "rank": 75,
+    "player": "DeVonta Smith",
+    "nfl_team": "Phi",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Diego",
+    "rank": 76,
+    "player": "Bills D/ST",
+    "nfl_team": "Buf",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 78,
+    "player": "Chase Edmonds",
+    "nfl_team": "TB",
+    "position": "RB",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Diego",
+    "rank": 82,
+    "player": "Allen Robinson II",
+    "nfl_team": "LAR",
+    "position": "WR",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Diego",
+    "rank": 96,
+    "player": "AJ Dillon",
+    "nfl_team": "GB",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 106,
+    "player": "Damien Harris",
+    "nfl_team": "Buf",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 116,
+    "player": "Kadarius Toney",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 125,
+    "player": "Michael Carter",
+    "nfl_team": "NYJ",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Diego",
+    "rank": 134,
+    "player": "Daniel Carlson",
+    "nfl_team": "LV",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Jordan",
+    "rank": 13,
+    "player": "Nick Chubb",
+    "nfl_team": "Cle",
+    "position": "RB",
+    "offer_amount": 36
+  },
+  {
+    "manager": "Jordan",
+    "rank": 16,
+    "player": "Mike Evans",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 29
+  },
+  {
+    "manager": "Jordan",
+    "rank": 23,
+    "player": "George Kittle",
+    "nfl_team": "SF",
+    "position": "TE",
+    "offer_amount": 19
+  },
+  {
+    "manager": "Jordan",
+    "rank": 26,
+    "player": "Kyle Pitts",
+    "nfl_team": "Atl",
+    "position": "TE",
+    "offer_amount": 23
+  },
+  {
+    "manager": "Jordan",
+    "rank": 41,
+    "player": "Josh Allen",
+    "nfl_team": "Buf",
+    "position": "QB",
+    "offer_amount": 26
+  },
+  {
+    "manager": "Jordan",
+    "rank": 45,
+    "player": "Gabe Davis",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 15
+  },
+  {
+    "manager": "Jordan",
+    "rank": 48,
+    "player": "Jerry Jeudy",
+    "nfl_team": "Den",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Jordan",
+    "rank": 62,
+    "player": "Darnell Mooney",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Jordan",
+    "rank": 63,
+    "player": "Tyler Lockett",
+    "nfl_team": "Sea",
+    "position": "WR",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Jordan",
+    "rank": 65,
+    "player": "Amon-Ra St. Brown",
+    "nfl_team": "Det",
+    "position": "WR",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Jordan",
+    "rank": 71,
+    "player": "Clyde Edwards-Helaire",
+    "nfl_team": "KC",
+    "position": "RB",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Jordan",
+    "rank": 81,
+    "player": "DeAndre Hopkins",
+    "nfl_team": "Ari",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 88,
+    "player": "Rhamondre Stevenson",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Jordan",
+    "rank": 93,
+    "player": "Cordarrelle Patterson",
+    "nfl_team": "Atl",
+    "position": "RB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 97,
+    "player": "Brandon Aiyuk",
+    "nfl_team": "SF",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 99,
+    "player": "49ers D/ST",
+    "nfl_team": "SF",
+    "position": "D/ST",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Jordan",
+    "rank": 108,
+    "player": "Matt Gay",
+    "nfl_team": "Ind",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 1,
+    "player": "Darren Waller",
+    "nfl_team": "NYG",
+    "position": "TE",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Nick J",
+    "rank": 3,
+    "player": "Cooper Kupp",
+    "nfl_team": "LAR",
+    "position": "WR",
+    "offer_amount": 44
+  },
+  {
+    "manager": "Nick J",
+    "rank": 17,
+    "player": "Ja'Marr Chase",
+    "nfl_team": "Cin",
+    "position": "WR",
+    "offer_amount": 55
+  },
+  {
+    "manager": "Nick J",
+    "rank": 21,
+    "player": "Aaron Jones",
+    "nfl_team": "GB",
+    "position": "RB",
+    "offer_amount": 49
+  },
+  {
+    "manager": "Nick J",
+    "rank": 50,
+    "player": "Patrick Mahomes",
+    "nfl_team": "KC",
+    "position": "QB",
+    "offer_amount": 14
+  },
+  {
+    "manager": "Nick J",
+    "rank": 55,
+    "player": "Michael Thomas",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Nick J",
+    "rank": 60,
+    "player": "JuJu Smith-Schuster",
+    "nfl_team": "NE",
+    "position": "WR",
+    "offer_amount": 10
+  },
+  {
+    "manager": "Nick J",
+    "rank": 72,
+    "player": "Devin Singletary",
+    "nfl_team": "Hou",
+    "position": "RB",
+    "offer_amount": 3
+  },
+  {
+    "manager": "Nick J",
+    "rank": 91,
+    "player": "Marquez Valdes-Scantling",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 101,
+    "player": "Harrison Butker",
+    "nfl_team": "KC",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 111,
+    "player": "James Robinson",
+    "nfl_team": "NE",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 120,
+    "player": "Kirk Cousins",
+    "nfl_team": "Min",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 129,
+    "player": "Russell Gage",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 138,
+    "player": "Jarvis Landry",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 146,
+    "player": "Deshaun Watson",
+    "nfl_team": "Cle",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 154,
+    "player": "Derek Carr",
+    "nfl_team": "NO",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Nick J",
+    "rank": 162,
+    "player": "Dolphins D/ST",
+    "nfl_team": "Mia",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 10,
+    "player": "Derrick Henry",
+    "nfl_team": "Ten",
+    "position": "RB",
+    "offer_amount": 65
+  },
+  {
+    "manager": "Luca",
+    "rank": 27,
+    "player": "Stefon Diggs",
+    "nfl_team": "Buf",
+    "position": "WR",
+    "offer_amount": 49
+  },
+  {
+    "manager": "Luca",
+    "rank": 28,
+    "player": "CeeDee Lamb",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 40
+  },
+  {
+    "manager": "Luca",
+    "rank": 37,
+    "player": "Terry McLaurin",
+    "nfl_team": "Wsh",
+    "position": "WR",
+    "offer_amount": 23
+  },
+  {
+    "manager": "Luca",
+    "rank": 56,
+    "player": "Miles Sanders",
+    "nfl_team": "Car",
+    "position": "RB",
+    "offer_amount": 6
+  },
+  {
+    "manager": "Luca",
+    "rank": 66,
+    "player": "Jalen Hurts",
+    "nfl_team": "Phi",
+    "position": "QB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 74,
+    "player": "Aaron Rodgers",
+    "nfl_team": "GB",
+    "position": "QB",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Luca",
+    "rank": 80,
+    "player": "Antonio Gibson",
+    "nfl_team": "Wsh",
+    "position": "RB",
+    "offer_amount": 4
+  },
+  {
+    "manager": "Luca",
+    "rank": 95,
+    "player": "Tony Pollard",
+    "nfl_team": "Dal",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 105,
+    "player": "Buccaneers D/ST",
+    "nfl_team": "TB",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 115,
+    "player": "Nyheim Hines",
+    "nfl_team": "Buf",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 124,
+    "player": "Pat Freiermuth",
+    "nfl_team": "Pit",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 133,
+    "player": "Skky Moore",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 142,
+    "player": "Mike Gesicki",
+    "nfl_team": "NE",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 150,
+    "player": "Michael Gallup",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 158,
+    "player": "Brandon McManus",
+    "nfl_team": "Den",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Luca",
+    "rank": 165,
+    "player": "Kenny Golladay",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 5,
+    "player": "Alvin Kamara",
+    "nfl_team": "NO",
+    "position": "RB",
+    "offer_amount": 43
+  },
+  {
+    "manager": "Sammy",
+    "rank": 25,
+    "player": "Leonard Fournette",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 39
+  },
+  {
+    "manager": "Sammy",
+    "rank": 32,
+    "player": "Elijah Mitchell",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 19
+  },
+  {
+    "manager": "Sammy",
+    "rank": 36,
+    "player": "Jaylen Waddle",
+    "nfl_team": "Mia",
+    "position": "WR",
+    "offer_amount": 21
+  },
+  {
+    "manager": "Sammy",
+    "rank": 42,
+    "player": "James Conner",
+    "nfl_team": "Ari",
+    "position": "RB",
+    "offer_amount": 33
+  },
+  {
+    "manager": "Sammy",
+    "rank": 47,
+    "player": "Brandin Cooks",
+    "nfl_team": "Dal",
+    "position": "WR",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Sammy",
+    "rank": 59,
+    "player": "Kyler Murray",
+    "nfl_team": "Ari",
+    "position": "QB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Sammy",
+    "rank": 67,
+    "player": "David Montgomery",
+    "nfl_team": "Det",
+    "position": "RB",
+    "offer_amount": 14
+  },
+  {
+    "manager": "Sammy",
+    "rank": 86,
+    "player": "Christian Kirk",
+    "nfl_team": "Jax",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Sammy",
+    "rank": 92,
+    "player": "Elijah Moore",
+    "nfl_team": "NYJ",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 102,
+    "player": "Robert Woods",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 112,
+    "player": "Rashaad Penny",
+    "nfl_team": "Phi",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 121,
+    "player": "Cole Kmet",
+    "nfl_team": "Chi",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 130,
+    "player": "Cowboys D/ST",
+    "nfl_team": "Dal",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 139,
+    "player": "Kenneth Walker III",
+    "nfl_team": "Sea",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 147,
+    "player": "Chargers D/ST",
+    "nfl_team": "LAC",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Sammy",
+    "rank": 155,
+    "player": "Nick Folk",
+    "nfl_team": "NE",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 4,
+    "player": "Dalvin Cook",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 47
+  },
+  {
+    "manager": "Logan",
+    "rank": 6,
+    "player": "D'Andre Swift",
+    "nfl_team": "Det",
+    "position": "RB",
+    "offer_amount": 41
+  },
+  {
+    "manager": "Logan",
+    "rank": 8,
+    "player": "Jonathan Taylor",
+    "nfl_team": "Ind",
+    "position": "RB",
+    "offer_amount": 65
+  },
+  {
+    "manager": "Logan",
+    "rank": 46,
+    "player": "Breece Hall",
+    "nfl_team": "NYJ",
+    "position": "RB",
+    "offer_amount": 16
+  },
+  {
+    "manager": "Logan",
+    "rank": 68,
+    "player": "Chris Godwin",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Logan",
+    "rank": 70,
+    "player": "Marquise Brown",
+    "nfl_team": "Ari",
+    "position": "WR",
+    "offer_amount": 7
+  },
+  {
+    "manager": "Logan",
+    "rank": 77,
+    "player": "Dameon Pierce",
+    "nfl_team": "Hou",
+    "position": "RB",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Logan",
+    "rank": 79,
+    "player": "Drake London",
+    "nfl_team": "Atl",
+    "position": "WR",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Logan",
+    "rank": 107,
+    "player": "Matthew Stafford",
+    "nfl_team": "LAR",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 117,
+    "player": "Chase Claypool",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 126,
+    "player": "James Cook",
+    "nfl_team": "Buf",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 135,
+    "player": "Rams D/ST",
+    "nfl_team": "LAR",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 143,
+    "player": "George Pickens",
+    "nfl_team": "Pit",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 151,
+    "player": "David Njoku",
+    "nfl_team": "Cle",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 159,
+    "player": "Isaiah McKenzie",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 166,
+    "player": "Tyron Davis-Price",
+    "nfl_team": "SF",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Logan",
+    "rank": 168,
+    "player": "Robbie Gould",
+    "nfl_team": "SF",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 14,
+    "player": "Travis Kelce",
+    "nfl_team": "KC",
+    "position": "TE",
+    "offer_amount": 38
+  },
+  {
+    "manager": "Mike",
+    "rank": 19,
+    "player": "Keenan Allen",
+    "nfl_team": "LAC",
+    "position": "WR",
+    "offer_amount": 32
+  },
+  {
+    "manager": "Mike",
+    "rank": 22,
+    "player": "Davante Adams",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 60
+  },
+  {
+    "manager": "Mike",
+    "rank": 31,
+    "player": "Ezekiel Elliott",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 26
+  },
+  {
+    "manager": "Mike",
+    "rank": 51,
+    "player": "J.K. Dobbins",
+    "nfl_team": "Bal",
+    "position": "RB",
+    "offer_amount": 8
+  },
+  {
+    "manager": "Mike",
+    "rank": 53,
+    "player": "Amari Cooper",
+    "nfl_team": "Cle",
+    "position": "WR",
+    "offer_amount": 9
+  },
+  {
+    "manager": "Mike",
+    "rank": 61,
+    "player": "Adam Thielen",
+    "nfl_team": "FA",
+    "position": "WR",
+    "offer_amount": 12
+  },
+  {
+    "manager": "Mike",
+    "rank": 64,
+    "player": "Hunter Renfrow",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 5
+  },
+  {
+    "manager": "Mike",
+    "rank": 83,
+    "player": "Dalton Schultz",
+    "nfl_team": "Hou",
+    "position": "TE",
+    "offer_amount": 2
+  },
+  {
+    "manager": "Mike",
+    "rank": 89,
+    "player": "Dak Prescott",
+    "nfl_team": "Dal",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 109,
+    "player": "Chris Olave",
+    "nfl_team": "NO",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 118,
+    "player": "Tyler Bass",
+    "nfl_team": "Buf",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 127,
+    "player": "Saints D/ST",
+    "nfl_team": "NO",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 136,
+    "player": "Alexander Mattison",
+    "nfl_team": "Min",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 144,
+    "player": "Julio Jones",
+    "nfl_team": "TB",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 152,
+    "player": "Jamaal Williams",
+    "nfl_team": "NO",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Mike",
+    "rank": 160,
+    "player": "Mecole Hardman",
+    "nfl_team": "KC",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 2,
+    "player": "Deebo Samuel",
+    "nfl_team": "SF",
+    "position": "WR",
+    "offer_amount": 39
+  },
+  {
+    "manager": "Adrian",
+    "rank": 12,
+    "player": "Austin Ekeler",
+    "nfl_team": "LAC",
+    "position": "RB",
+    "offer_amount": 63
+  },
+  {
+    "manager": "Adrian",
+    "rank": 29,
+    "player": "Michael Pittman Jr.",
+    "nfl_team": "Ind",
+    "position": "WR",
+    "offer_amount": 34
+  },
+  {
+    "manager": "Adrian",
+    "rank": 39,
+    "player": "Travis Etienne Jr.",
+    "nfl_team": "Jax",
+    "position": "RB",
+    "offer_amount": 22
+  },
+  {
+    "manager": "Adrian",
+    "rank": 49,
+    "player": "Josh Jacobs",
+    "nfl_team": "LV",
+    "position": "RB",
+    "offer_amount": 18
+  },
+  {
+    "manager": "Adrian",
+    "rank": 54,
+    "player": "Evan McPherson",
+    "nfl_team": "Cin",
+    "position": "K",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 69,
+    "player": "DJ Moore",
+    "nfl_team": "Chi",
+    "position": "WR",
+    "offer_amount": 13
+  },
+  {
+    "manager": "Adrian",
+    "rank": 84,
+    "player": "Packers D/ST",
+    "nfl_team": "GB",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 94,
+    "player": "Joe Burrow",
+    "nfl_team": "Cin",
+    "position": "QB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 104,
+    "player": "Zach Ertz",
+    "nfl_team": "Ari",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 114,
+    "player": "Melvin Gordon III",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 123,
+    "player": "Hunter Henry",
+    "nfl_team": "NE",
+    "position": "TE",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 132,
+    "player": "Jakobi Meyers",
+    "nfl_team": "LV",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 141,
+    "player": "Ravens D/ST",
+    "nfl_team": "Bal",
+    "position": "D/ST",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 149,
+    "player": "J.D. McKissic",
+    "nfl_team": "FA",
+    "position": "RB",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 157,
+    "player": "Treylon Burks",
+    "nfl_team": "Ten",
+    "position": "WR",
+    "offer_amount": 1
+  },
+  {
+    "manager": "Adrian",
+    "rank": 164,
+    "player": "Justin Fields",
+    "nfl_team": "Chi",
+    "position": "QB",
+    "offer_amount": 1
+  }
+]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,8 +75,8 @@ function ErrorState({ message, onRetry }: { message: string; onRetry: () => void
 }
 
 function AppData() {
-  const [route, setRoute] = useState<'board' | 'analytics' | 'draft'>(() => window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.match(/\/draft-rankings\/(2023|2024|2025)$/) ? 'draft' : 'board')
-  const [draftSeason, setDraftSeason] = useState<2023 | 2024 | 2025>(() => window.location.pathname.endsWith('/draft-rankings/2023') ? 2023 : window.location.pathname.endsWith('/draft-rankings/2024') ? 2024 : 2025)
+  const [route, setRoute] = useState<'board' | 'analytics' | 'draft'>(() => window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : window.location.pathname.match(/\/draft-rankings\/(2022|2023|2024|2025)$/) ? 'draft' : 'board')
+  const [draftSeason, setDraftSeason] = useState<2022 | 2023 | 2024 | 2025>(() => window.location.pathname.endsWith('/draft-rankings/2022') ? 2022 : window.location.pathname.endsWith('/draft-rankings/2023') ? 2023 : window.location.pathname.endsWith('/draft-rankings/2024') ? 2024 : 2025)
   const [manifest, setManifest] = useState<DataManifest>(emptyManifest)
   const [teams, setTeams] = useState<Record<string, TeamAsset>>({})
   const [rows, setRows] = useState<RankingRow[]>([])
@@ -94,9 +94,9 @@ function AppData() {
 
   useEffect(() => {
     const handlePopState = () => {
-      const match = window.location.pathname.match(/\/draft-rankings\/(2023|2024|2025)$/)
+      const match = window.location.pathname.match(/\/draft-rankings\/(2022|2023|2024|2025)$/)
       setRoute(window.location.pathname.endsWith('/analytics/rankings-diff') ? 'analytics' : match ? 'draft' : 'board')
-      if (match) setDraftSeason(Number(match[1]) as 2023 | 2024 | 2025)
+      if (match) setDraftSeason(Number(match[1]) as 2022 | 2023 | 2024 | 2025)
     }
     window.addEventListener('popstate', handlePopState)
     return () => window.removeEventListener('popstate', handlePopState)
@@ -118,14 +118,15 @@ function AppData() {
       fetchJson<DataManifest>('/data/manifest.json', controller.signal),
       fetchJson<Record<string, TeamAsset>>('/data/assets/espn_nfl_teams.json', controller.signal).catch(() => ({})),
       fetchJson<SourceCheckPayload>('/data/status/source_checks.json', controller.signal).catch(() => undefined),
+      fetchJson<DraftRankingRow[]>('/data/2022/draft-rankings.json', controller.signal),
       fetchJson<DraftRankingRow[]>('/data/2023/draft-rankings.json', controller.signal),
       fetchJson<DraftRankingRow[]>('/data/2024/draft-rankings.json', controller.signal),
       fetchJson<DraftRankingRow[]>('/data/2025/draft-rankings.json', controller.signal)
-    ]).then(([loadedManifest, loadedTeams, loadedChecks, loadedDraftRows2023, loadedDraftRows2024, loadedDraftRows2025]) => {
+    ]).then(([loadedManifest, loadedTeams, loadedChecks, loadedDraftRows2022, loadedDraftRows2023, loadedDraftRows2024, loadedDraftRows2025]) => {
       setManifest(loadedManifest)
       setTeams(loadedTeams)
       setSourceChecks(loadedChecks)
-      setDraftRowsBySeason({ 2023: loadedDraftRows2023, 2024: loadedDraftRows2024, 2025: loadedDraftRows2025 })
+      setDraftRowsBySeason({ 2022: loadedDraftRows2022, 2023: loadedDraftRows2023, 2024: loadedDraftRows2024, 2025: loadedDraftRows2025 })
       const firstSeason = loadedManifest.seasons[0]
       const sharedDraft = readDraftShare(new URLSearchParams(window.location.search).get('draft'))
       let saved: { season?: number; source?: string; adjustedProfile?: string } = {}

--- a/frontend/src/components/DraftRankingsPage.tsx
+++ b/frontend/src/components/DraftRankingsPage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import type { DraftRankingRow } from '../types'
 
 type SortKey = 'rank' | 'player' | 'position' | 'offer_amount' | 'manager' | 'nfl_team'
-type Props = { season: 2023 | 2024 | 2025; rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
+type Props = { season: 2022 | 2023 | 2024 | 2025; rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
 
 const POSITION_ORDER = ['ALL', 'QB', 'RB', 'WR', 'TE', 'K', 'D/ST']
 const DRAFT_SIZE = 10

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -117,6 +117,13 @@ test('2023 auction rankings loads from its own direct route', async ({ page }) =
   await expect(page.getByText('Sammy', { exact: true }).first()).toBeVisible()
 })
 
+test('2022 auction rankings loads from its own direct route', async ({ page }) => {
+  await page.goto('./draft-rankings/2022')
+  await expect(page.getByRole('heading', { name: '2022 Draft' })).toBeVisible()
+  await expect(page.locator('.draft-rankings-table tbody tr').filter({ hasText: 'Austin Ekeler' })).toBeVisible()
+  await expect(page.getByText('Adrian', { exact: true }).first()).toBeVisible()
+})
+
 test('trend is off by default and can be shown and sorted', async ({ page }) => {
   await page.goto('./')
   await expect(page.getByRole('columnheader', { name: /regression/i })).toHaveCount(0)


### PR DESCRIPTION
## Summary
- Adds the 2022 auction draft dataset using manager aliases only.
- Supports `/draft-rankings/2022` alongside 2023–2025.
- Keeps drafted-state storage separate by season.

## Testing
- `asdf exec npm --prefix frontend run lint`
- `asdf exec npm --prefix frontend run test`
- `asdf exec npm --prefix frontend run build`
- Chromium direct-route test for 2022 passes.

## Release
- Bumps version to 1.66.5.