### PR TITLE
Add historic league average views

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.5",
+  "version": "1.67.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.66.5",
+      "version": "1.67.0",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.66.5",
+  "version": "1.67.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -192,7 +192,7 @@ function AppData() {
   if (error) return <ErrorState message={error} onRetry={() => { setRows([]); setRowsLoading(true); setHasLoadedRows(false); setRetryKey((current) => current + 1) }} />
   if (manifestLoading || !manifest.seasons.length || !selectedSource || !hasLoadedRows) return <LoadingState detail={manifestLoading ? undefined : `Loading ${selectedMeta?.label ?? 'the selected source'} rankings…`} />
 
-  if (route === 'draft') return <DraftRankingsPage season={draftSeason} rows={draftRowsBySeason[draftSeason] ?? []} onNavigate={navigate} />
+  if (route === 'draft') return <DraftRankingsPage season={draftSeason} rows={draftRowsBySeason[draftSeason] ?? []} rowsBySeason={draftRowsBySeason} onNavigate={navigate} />
 
   const displayedRows = applyAdjustedProfile(rows, selectedProfile?.id ?? 'full-ppr', selectedSource)
   return <RankingsDashboard manifest={manifest} rows={displayedRows} teams={teams} yahooProjections={yahooProjections} sourceChecks={sourceChecks} selectedSeason={selectedSeason} selectedSource={selectedSource} adjustedProfiles={adjustedProfiles} selectedAdjustedProfile={selectedProfile?.id ?? 'full-ppr'} onAdjustedProfile={setSelectedAdjustedProfile} onSeason={handleSeason} onSource={setSelectedSource} route={route} onNavigate={navigate} />

--- a/frontend/src/components/DraftRankingsPage.tsx
+++ b/frontend/src/components/DraftRankingsPage.tsx
@@ -1,17 +1,23 @@
 import { useMemo, useState } from 'react'
 import type { DraftRankingRow } from '../types'
+import { ViewTabs } from './ViewTabs'
 
 type SortKey = 'rank' | 'player' | 'position' | 'offer_amount' | 'manager' | 'nfl_team'
-type Props = { season: 2022 | 2023 | 2024 | 2025; rows: DraftRankingRow[]; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
+type Props = { season: 2022 | 2023 | 2024 | 2025; rows: DraftRankingRow[]; rowsBySeason: Record<number, DraftRankingRow[]>; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
+type HistoricalPosition = 'RB' | 'WR' | 'QB' | 'TE'
 
 const POSITION_ORDER = ['ALL', 'QB', 'RB', 'WR', 'TE', 'K', 'D/ST']
 const DRAFT_SIZE = 10
 const STORAGE_KEY = 'rankingsdiff:auction-results:v1:2025'
+const HISTORIC_LIMITS: Record<HistoricalPosition, number> = { RB: 30, WR: 30, QB: 15, TE: 15 }
+const HISTORIC_POSITIONS: HistoricalPosition[] = ['RB', 'WR', 'QB', 'TE']
 
 function rowId(row: DraftRankingRow): string { return `${row.player.toLowerCase()}|${row.nfl_team.toLowerCase()}` }
 function money(value: number): string { return `$${value}` }
 
-export function DraftRankingsPage({ season, rows, onNavigate }: Props) {
+export function DraftRankingsPage({ season, rows, rowsBySeason, onNavigate }: Props) {
+  const [view, setView] = useState<'results' | 'averages'>('results')
+  const [averagePosition, setAveragePosition] = useState<HistoricalPosition>('RB')
   const [position, setPosition] = useState('ALL')
   const [search, setSearch] = useState('')
   const [sortKey, setSortKey] = useState<SortKey>('offer_amount')
@@ -58,12 +64,29 @@ export function DraftRankingsPage({ season, rows, onNavigate }: Props) {
   const undraftedCount = filteredRows.length - draftedCount
   const mostExpensive = useMemo(() => [...rows].sort((a, b) => b.offer_amount - a.offer_amount)[0], [rows])
   const mostExpensiveByPosition = useMemo(() => ['QB', 'RB', 'WR', 'TE', 'K'].map((key) => ({ position: key, row: rows.filter((row) => row.position === key).sort((a, b) => b.offer_amount - a.offer_amount)[0] })).filter((item) => item.row), [rows])
+  const averageRows = useMemo(() => {
+    const seasons: Array<2022 | 2023 | 2024 | 2025> = [2022, 2023, 2024, 2025]
+    const bySeason = new Map<number, DraftRankingRow[]>()
+    seasons.forEach((year) => bySeason.set(year, rowsBySeason[year] ?? []))
+    return Array.from({ length: HISTORIC_LIMITS[averagePosition] }, (_, index) => {
+      const prices = seasons.map((year) => bySeason.get(year)?.filter((row) => row.position === averagePosition).sort((a, b) => b.offer_amount - a.offer_amount)[index]?.offer_amount)
+      const present = prices.filter((price): price is number => typeof price === 'number')
+      return { rank: index + 1, prices, total: present.reduce((sum, price) => sum + price, 0), average: present.length ? present.reduce((sum, price) => sum + price, 0) / present.length : null }
+    }).filter((row) => row.average !== null)
+  }, [averagePosition, rowsBySeason])
 
   return <main className="dashboard draft-rankings-page">
     <section className="hero hero--compact hero--editorial" aria-label="Draft rankings header">
       <div className="hero__brand"><div className="loading-mark draft-rankings-mark" aria-hidden="true"><span>{season}</span></div><div><span className="eyebrow">Auction results</span><h1>{season} Draft</h1><p className="view-summary"><strong>{rows.length}</strong> players · <strong>{new Set(rows.map((row) => row.manager)).size}</strong> managers</p></div></div>
-      <div className="hero__context"><div className="hero__context-actions"><span>Draft rankings</span><button className="settings-icon-trigger" type="button" onClick={() => onNavigate('board')} aria-label="Back to rankings board">×</button></div><div className="hero__context-bottom"><button className="analytics-link" type="button" onClick={() => onNavigate('board')}>Rankings board</button><button className="analytics-link" type="button" onClick={() => onNavigate('analytics')}>Rankings diff</button></div></div>
+      <div className="hero__context"><ViewTabs active="draft" onNavigate={onNavigate} /></div>
     </section>
+
+    <section className="draft-view-switcher" aria-label="Historic results views"><button type="button" className={view === 'results' ? 'active' : ''} onClick={() => setView('results')}>Player results</button><button type="button" className={view === 'averages' ? 'active' : ''} onClick={() => setView('averages')}>League averages</button></section>
+
+    {view === 'averages' ? <section className="historic-averages" aria-label="League average auction prices">
+      <div className="historic-averages__intro"><div><span className="eyebrow">Across 2022–2025</span><h2>League average prices</h2><p>Compare the average auction cost and total spend for each positional slot across the four historical drafts.</p></div><div className="position-pills">{HISTORIC_POSITIONS.map((key) => <button type="button" key={key} className={averagePosition === key ? 'active' : ''} onClick={() => setAveragePosition(key)}>{key} · top {HISTORIC_LIMITS[key]}</button>)}</div></div>
+      <div className="table-wrap historic-averages__table-wrap"><table className="rankings-table historic-averages__table"><thead><tr><th>Slot</th><th>Average / year</th><th>Total</th><th>2022</th><th>2023</th><th>2024</th><th>2025</th></tr></thead><tbody>{averageRows.map((row) => <tr key={row.rank}><td><strong>{averagePosition}{row.rank}</strong></td><td className="num"><strong>{row.average === null ? '—' : money(Math.round(row.average))}</strong></td><td className="num">{money(row.total)}</td>{row.prices.map((price, index) => <td className="num" key={`${row.rank}-${index}`}>{price === undefined ? '—' : money(price)}</td>)}</tr>)}</tbody></table></div>
+    </section> : <>
 
     <section className="draft-rankings-summary" aria-label="Draft highlights">
       <article><span className="eyebrow">Most expensive</span><strong>{mostExpensive ? `${mostExpensive.player} · ${money(mostExpensive.offer_amount)}` : '—'}</strong><small>{mostExpensive?.manager ?? ''}</small></article>
@@ -81,6 +104,6 @@ export function DraftRankingsPage({ season, rows, onNavigate }: Props) {
     <div className="table-wrap draft-rankings-table-wrap"><table className="rankings-table draft-rankings-table"><thead><tr><th><button className="sort-button" onClick={() => sortBy('rank')}>Rank{sortKey === 'rank' ? ` ${sortDirection === 'asc' ? '↑' : '↓'}` : ''}</button></th><th><button className="sort-button" onClick={() => sortBy('player')}>Player{sortKey === 'player' ? ` ${sortDirection === 'asc' ? '↑' : '↓'}` : ''}</button></th><th><button className="sort-button" onClick={() => sortBy('position')}>Pos{sortKey === 'position' ? ` ${sortDirection === 'asc' ? '↑' : '↓'}` : ''}</button></th><th><button className="sort-button" onClick={() => sortBy('manager')}>Manager{sortKey === 'manager' ? ` ${sortDirection === 'asc' ? '↑' : '↓'}` : ''}</button></th><th><button className="sort-button" onClick={() => sortBy('offer_amount')}>Offer{sortKey === 'offer_amount' ? ` ${sortDirection === 'asc' ? '↑' : '↓'}` : ''}</button></th><th>Status</th></tr></thead><tbody>
       {filteredRows.map((row, index) => <>{index > 0 && index % DRAFT_SIZE === 0 ? <tr className="draft-rankings-divider" key={`divider-${index}`}><td colSpan={6}><span>Top {index}</span><small>{filteredRows.slice(0, index).filter((item) => drafted.has(rowId(item))).length} drafted · {index - filteredRows.slice(0, index).filter((item) => drafted.has(rowId(item))).length} undrafted</small></td></tr> : null}<tr className={drafted.has(rowId(row)) ? '' : 'is-undrafted'} key={rowId(row)}><td className="num">{row.rank}</td><td><strong>{row.player}</strong><small className="draft-rankings-team">{row.nfl_team}</small></td><td><span className={`pos-chip pos-${row.position.toLowerCase().replace('/', '-')}`}>{row.position}</span></td><td>{row.manager}</td><td className="num"><strong>{money(row.offer_amount)}</strong></td><td><button type="button" className="draft-status-button" onClick={() => toggleDrafted(row)}>{drafted.has(rowId(row)) ? 'Drafted' : 'Undrafted'}</button></td></tr></>)}
       {!filteredRows.length ? <tr><td colSpan={6}><div className="empty-state">No players match the current filters.</div></td></tr> : null}
-    </tbody></table></div>
+    </tbody></table></div></>}
   </main>
 }

--- a/frontend/src/components/RankingsDashboard.tsx
+++ b/frontend/src/components/RankingsDashboard.tsx
@@ -12,6 +12,7 @@ import { RecentDraftPanel } from './RecentDraftPanel'
 import { AuctionRosterPanel } from './AuctionRosterPanel'
 import { withBasePath } from '../data/paths'
 import { RankingsDiffChart } from './RankingsDiffChart'
+import { ViewTabs } from './ViewTabs'
 
 type ViewMode = 'board' | 'positions'
 type DraftMode = 'snake' | 'auction'
@@ -738,7 +739,7 @@ export function RankingsDashboard({ manifest, rows, teams, yahooProjections, sou
             <div className="view-summary" aria-live="polite">
               <strong>{selectedSeason}</strong> · <strong>{(source?.label ?? selectedSource).replace(/\s+vs\s+Yahoo$/i, '')}</strong> · <strong>{projectionMode === 'half' ? 'Half PPR' : 'Full PPR'}</strong> · <strong>{draftMode === 'auction' ? 'Auction' : 'Snake'}</strong> · <strong>{draftSlot}/{draftSize}</strong>
             </div>
-            <div className="hero__links"><button className="analytics-link" type="button" onClick={() => onNavigate('analytics')}>Rankings diff</button><button className="analytics-link" type="button" onClick={() => onNavigate('draft')}>2025 auction</button></div>
+            <ViewTabs active={route} onNavigate={onNavigate} />
           </div>
         </div>
       </section>
@@ -859,7 +860,7 @@ export function RankingsDashboard({ manifest, rows, teams, yahooProjections, sou
       />
     </main>
     <div hidden={route !== 'analytics'}>
-      <RankingsDiffChart rows={displayRows} teams={teams} source={selectedSource} drafted={drafted} onBack={() => onNavigate('board')} />
+      <RankingsDiffChart rows={displayRows} teams={teams} source={selectedSource} drafted={drafted} onNavigate={onNavigate} />
     </div>
   </>)
 }

--- a/frontend/src/components/RankingsDiffChart.tsx
+++ b/frontend/src/components/RankingsDiffChart.tsx
@@ -4,13 +4,14 @@ import { calculateRegression, formatRank, formatValue, regressionDifference, sou
 import { getTeamAsset } from '../data/teams'
 import { rankingId } from '../data/draftState'
 import { TeamBadge } from './TeamBadge'
+import { ViewTabs } from './ViewTabs'
 
 type Props = {
   rows: RankingRow[]
   teams: Record<string, TeamAsset>
   source: string
   drafted: Set<string>
-  onBack: () => void
+  onNavigate: (path: 'board' | 'analytics' | 'draft') => void
 }
 
 type WindowOption = { id: string; label: string; start: number; end?: number }
@@ -36,7 +37,7 @@ function windowOptions(maxRank: number): WindowOption[] {
   ]
 }
 
-export function RankingsDiffChart({ rows, teams, source, drafted, onBack }: Props) {
+export function RankingsDiffChart({ rows, teams, source, drafted, onNavigate }: Props) {
   const maxRank = rankMax(rows)
   const windows = windowOptions(maxRank)
   const [position, setPosition] = useState<PositionFilter>('ALL')
@@ -105,7 +106,7 @@ export function RankingsDiffChart({ rows, teams, source, drafted, onBack }: Prop
         <h1>Rankings diff</h1>
         <p>{sourceLabel(source)} base rank vs. adjusted overall rank</p>
       </div>
-      <button className="secondary-action" type="button" onClick={onBack}>← Back to rankings</button>
+      <ViewTabs active="analytics" onNavigate={onNavigate} />
     </header>
 
     <section className="rankings-diff-controls" aria-label="Rankings diff filters">

--- a/frontend/src/components/ViewTabs.tsx
+++ b/frontend/src/components/ViewTabs.tsx
@@ -1,0 +1,15 @@
+type ViewRoute = 'board' | 'analytics' | 'draft'
+
+type Props = { active: ViewRoute; onNavigate: (path: ViewRoute) => void }
+
+const tabs: Array<{ route: ViewRoute; label: string }> = [
+  { route: 'board', label: 'Draft board' },
+  { route: 'draft', label: 'Historic results' },
+  { route: 'analytics', label: 'Charts' }
+]
+
+export function ViewTabs({ active, onNavigate }: Props) {
+  return <nav className="view-tabs" aria-label="Primary views">
+    {tabs.map((tab) => <button key={tab.route} type="button" className={active === tab.route ? 'active' : ''} aria-current={active === tab.route ? 'page' : undefined} onClick={() => onNavigate(tab.route)}>{tab.label}</button>)}
+  </nav>
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2133,6 +2133,10 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 
 /* 2025 auction draft results */
 .hero__links { display: flex; gap: 8px; flex-wrap: wrap; }
+.view-tabs { display: inline-flex; gap: 3px; padding: 3px; border: 1px solid var(--line); border-radius: 12px; background: color-mix(in srgb, var(--panel) 88%, var(--accent-soft)); }
+.view-tabs button { min-height: 32px; border: 0; border-radius: 9px; padding: 7px 11px; color: var(--muted); background: transparent; font-size: .74rem; font-weight: 850; white-space: nowrap; }
+.view-tabs button:hover, .view-tabs button:focus-visible { color: var(--accent); background: var(--accent-soft); outline: 0; }
+.view-tabs button.active { color: var(--ink); background: var(--panel); box-shadow: var(--shadow-sm); }
 .draft-rankings-page { max-width: 1440px; }
 .draft-rankings-mark { width: 58px; height: 58px; margin: 0; border-radius: 18px; font-size: 1.1rem; letter-spacing: -.06em; }
 .draft-rankings-summary { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 10px; margin: 18px 0 12px; }
@@ -2154,5 +2158,18 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 .draft-status-button:hover, .draft-status-button:focus-visible { border-color: var(--accent); color: var(--accent); background: var(--accent-soft); }
 .draft-rankings-divider td { padding: 9px 14px; border-top: 2px solid color-mix(in srgb, var(--accent) 35%, var(--line)); border-bottom: 1px solid var(--line); color: var(--accent); background: color-mix(in srgb, var(--accent-soft) 72%, var(--panel)); font-size: .76rem; font-weight: 850; letter-spacing: .06em; text-transform: uppercase; }
 .draft-rankings-divider small { margin-left: 14px; color: var(--muted); font-size: .72rem; font-weight: 700; letter-spacing: 0; text-transform: none; }
-@media (max-width: 980px) { .draft-rankings-summary { grid-template-columns: repeat(3, minmax(0, 1fr)); } .draft-rankings-controls { grid-template-columns: 1fr; } .drafted-toggle { justify-self: start; } }
-@media (max-width: 620px) { .draft-rankings-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); } .draft-rankings-summary article:first-child { grid-column: 1 / -1; } .draft-rankings-meta { align-items: flex-start; flex-direction: column; } .draft-rankings-meta span { margin-left: 0; } .hero__links { justify-content: flex-start; } }
+.draft-view-switcher { display: flex; gap: 4px; width: fit-content; margin: 14px 0 16px; padding: 4px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
+.draft-view-switcher button { border: 0; border-radius: 8px; padding: 8px 13px; color: var(--muted); background: transparent; font-size: .78rem; font-weight: 850; }
+.draft-view-switcher button.active { color: var(--ink); background: var(--accent-soft); }
+.historic-averages { display: grid; gap: 14px; }
+.historic-averages__intro { display: flex; justify-content: space-between; gap: 24px; align-items: end; padding: 18px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); box-shadow: var(--shadow-sm); }
+.historic-averages__intro h2 { margin: 4px 0; font-size: 1.25rem; letter-spacing: -.04em; }
+.historic-averages__intro p { max-width: 580px; margin: 0; color: var(--muted); font-size: .83rem; line-height: 1.45; }
+.historic-averages__intro .position-pills { justify-content: flex-end; }
+.historic-averages__table-wrap { overflow-x: auto; }
+.historic-averages__table { min-width: 720px; }
+.historic-averages__table th, .historic-averages__table td { padding: 11px 14px; }
+.historic-averages__table th:not(:first-child), .historic-averages__table td:not(:first-child) { text-align: right; }
+.historic-averages__table tbody tr:first-child td { border-top: 2px solid color-mix(in srgb, var(--accent) 35%, var(--line)); }
+@media (max-width: 980px) { .draft-rankings-summary { grid-template-columns: repeat(3, minmax(0, 1fr)); } .draft-rankings-controls { grid-template-columns: 1fr; } .drafted-toggle { justify-self: start; } .historic-averages__intro { align-items: flex-start; flex-direction: column; } .historic-averages__intro .position-pills { justify-content: flex-start; } }
+@media (max-width: 620px) { .draft-rankings-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); } .draft-rankings-summary article:first-child { grid-column: 1 / -1; } .draft-rankings-meta { align-items: flex-start; flex-direction: column; } .draft-rankings-meta span { margin-left: 0; } .hero__links { justify-content: flex-start; } .view-tabs { width: 100%; } .view-tabs button { flex: 1; padding-inline: 6px; font-size: .69rem; } }

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2047,6 +2047,7 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 .hero--editorial .hero__context-actions > span { color: var(--muted); font-size: .66rem; font-weight: 850; letter-spacing: .09em; text-transform: uppercase; }
 .hero--editorial .hero__context-actions .settings-icon-trigger { width: 34px; height: 34px; }
 .hero--editorial .hero__context-actions .settings-icon-trigger img { width: 18px; height: 18px; }
+.hero--editorial .hero__context, .hero--editorial .hero__context-bottom, .hero--editorial .view-summary { min-width: 0; }
 .hero--editorial .hero__context-bottom { display: flex; min-height: 34px; width: 100%; gap: var(--space-3); align-items: center; justify-content: space-between; }
 .hero--editorial .hero__context-bottom .view-summary { justify-content: flex-start; }
 .hero--editorial .view-summary { justify-content: flex-end; gap: 5px; font-size: .78rem; }
@@ -2054,6 +2055,7 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 @media (max-width: 760px) {
   .hero--editorial { grid-template-columns: 1fr; gap: var(--space-3); align-items: start; margin-bottom: var(--space-3); }
   .hero--editorial .hero__context { justify-items: start; padding-left: 0; border-left: 0; }
+  .hero--editorial .hero__context-bottom { align-items: stretch; flex-direction: column; }
   .hero--editorial .view-summary { justify-content: flex-start; flex-wrap: wrap; }
 }
 

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -53,7 +53,7 @@ test('rankings diff opens as a separate route and returns without disturbing dra
   await page.goto('./')
   await page.getByRole('button', { name: 'Mark drafted Jahmyr Gibbs' }).first().click()
   await page.getByRole('button', { name: 'WR', exact: true }).first().click()
-  await page.getByRole('button', { name: 'Rankings diff', exact: true }).click()
+  await page.getByRole('button', { name: 'Charts', exact: true }).click()
 
   await expect(page).toHaveURL(/\/analytics\/rankings-diff$/)
   await expect(page.getByRole('heading', { name: 'Rankings diff' })).toBeVisible()
@@ -73,7 +73,7 @@ test('rankings diff opens as a separate route and returns without disturbing dra
   await page.getByRole('spinbutton', { name: 'End pick' }).fill('180')
   await expect(page.locator('.rankings-diff-card__header')).toContainText('Picks 80–180')
 
-  await page.getByRole('button', { name: '← Back to rankings' }).click()
+  await page.getByRole('button', { name: 'Draft board', exact: true }).click()
   await expect(page).toHaveURL(/\/RankingsDiff\/$|\/$/)
   await expect(page.getByRole('button', { name: 'WR', exact: true }).first()).toHaveClass(/active/)
   await page.getByRole('button', { name: 'ALL', exact: true }).first().click()
@@ -83,7 +83,7 @@ test('rankings diff opens as a separate route and returns without disturbing dra
 test('rankings diff direct URL loads as a first-class view', async ({ page }) => {
   await page.goto('./analytics/rankings-diff')
   await expect(page.getByRole('heading', { name: 'Rankings diff' })).toBeVisible()
-  await expect(page.getByRole('button', { name: '← Back to rankings' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Draft board', exact: true })).toBeVisible()
 })
 
 test('2025 auction rankings supports manager aliases, position sorting, and live draft dividers', async ({ page }) => {
@@ -122,6 +122,18 @@ test('2022 auction rankings loads from its own direct route', async ({ page }) =
   await expect(page.getByRole('heading', { name: '2022 Draft' })).toBeVisible()
   await expect(page.locator('.draft-rankings-table tbody tr').filter({ hasText: 'Austin Ekeler' })).toBeVisible()
   await expect(page.getByText('Adrian', { exact: true }).first()).toBeVisible()
+})
+
+test('historic results offers positional league averages across all seasons', async ({ page }) => {
+  await page.goto('./draft-rankings/2025')
+  await page.getByRole('button', { name: 'League averages', exact: true }).click()
+  await expect(page.getByRole('heading', { name: 'League average prices' })).toBeVisible()
+  await expect(page.getByRole('button', { name: 'RB · top 30', exact: true })).toHaveClass(/active/)
+  await expect(page.locator('.historic-averages__table tbody tr').first()).toContainText('RB1')
+  await expect(page.locator('.historic-averages__table thead')).toContainText('2022')
+  await page.getByRole('button', { name: 'TE · top 15', exact: true }).click()
+  await expect(page.locator('.historic-averages__table tbody tr').first()).toContainText('TE1')
+  await expect(page.locator('.historic-averages__table tbody tr')).toHaveCount(15)
 })
 
 test('trend is off by default and can be shown and sorted', async ({ page }) => {


### PR DESCRIPTION
Adds shared Draft board, Historic results, and Charts navigation; adds league-average auction view for RB/WR top 30 and QB/TE top 15 with average per year, total spend, and season values; preserves auction round separators. Validated with lint, unit tests, production build, and Chromium UI checks.