### PR TITLE
Normalize historical manager aliases

### DIFF
--- a/data/raw/2022/draft_rankings.csv
+++ b/data/raw/2022/draft_rankings.csv
@@ -16,23 +16,23 @@ Dane,163,Noah Fant,Sea,TE,1
 Dane,167,Kenneth Gainwell,Phi,RB,1
 Dane,169,Khalil Herbert,Chi,RB,1
 Dane,170,Joshua Palmer,LAC,WR,1
-Nick H,7,Justin Jefferson,Min,WR,52
-Nick H,9,Joe Mixon,Cin,RB,46
-Nick H,33,T.J. Hockenson,Min,TE,8
-Nick H,34,Javonte Williams,Den,RB,38
-Nick H,38,Cam Akers,LAR,RB,27
-Nick H,52,Diontae Johnson,Pit,WR,16
-Nick H,85,Kareem Hunt,Cle,RB,2
-Nick H,87,Russell Wilson,Den,QB,2
-Nick H,90,Rashod Bateman,Bal,WR,1
-Nick H,100,Dallas Goedert,Phi,TE,1
-Nick H,110,Tom Brady,TB,QB,1
-Nick H,119,Garrett Wilson,NYJ,WR,1
-Nick H,128,Trey Lance,SF,QB,1
-Nick H,137,Robbie Anderson,FA,WR,1
-Nick H,145,Darrell Henderson Jr.,FA,RB,1
-Nick H,153,Steelers D/ST,Pit,D/ST,1
-Nick H,161,Matt Prater,Ari,K,1
+Nick H.,7,Justin Jefferson,Min,WR,52
+Nick H.,9,Joe Mixon,Cin,RB,46
+Nick H.,33,T.J. Hockenson,Min,TE,8
+Nick H.,34,Javonte Williams,Den,RB,38
+Nick H.,38,Cam Akers,LAR,RB,27
+Nick H.,52,Diontae Johnson,Pit,WR,16
+Nick H.,85,Kareem Hunt,Cle,RB,2
+Nick H.,87,Russell Wilson,Den,QB,2
+Nick H.,90,Rashod Bateman,Bal,WR,1
+Nick H.,100,Dallas Goedert,Phi,TE,1
+Nick H.,110,Tom Brady,TB,QB,1
+Nick H.,119,Garrett Wilson,NYJ,WR,1
+Nick H.,128,Trey Lance,SF,QB,1
+Nick H.,137,Robbie Anderson,FA,WR,1
+Nick H.,145,Darrell Henderson Jr.,FA,RB,1
+Nick H.,153,Steelers D/ST,Pit,D/ST,1
+Nick H.,161,Matt Prater,Ari,K,1
 Diego,20,Mark Andrews,Bal,TE,35
 Diego,24,A.J. Brown,Phi,WR,25
 Diego,30,Saquon Barkley,NYG,RB,36

--- a/data/raw/2023/draft_rankings.csv
+++ b/data/raw/2023/draft_rankings.csv
@@ -16,23 +16,23 @@ Dane,148,Jameson Williams,Det,WR,1
 Dane,155,Damien Harris,Buf,RB,1
 Dane,162,Geno Smith,Sea,QB,1
 Dane,168,Kenneth Gainwell,Phi,RB,1
-Nick H,15,Travis Kelce,KC,TE,55
-Nick H,28,Tee Higgins,Cin,WR,26
-Nick H,34,CeeDee Lamb,Dal,WR,46
-Nick H,41,Jahmyr Gibbs,Det,RB,21
-Nick H,59,DeVonta Smith,Phi,WR,24
-Nick H,61,James Cook,Buf,RB,9
-Nick H,76,Trevor Lawrence,Jax,QB,2
-Nick H,83,David Montgomery,Det,RB,6
-Nick H,108,JuJu Smith-Schuster,NE,WR,2
-Nick H,113,Daniel Carlson,LV,K,1
-Nick H,123,Allen Lazard,NYJ,WR,1
-Nick H,131,Adam Thielen,Car,WR,2
-Nick H,133,Ravens D/ST,Bal,D/ST,1
-Nick H,142,K.J. Osborn,NE,WR,1
-Nick H,149,Tyler Higbee,LAR,TE,1
-Nick H,156,Gus Edwards,LAC,RB,1
-Nick H,163,Hunter Renfrow,LV,WR,1
+Nick H.,15,Travis Kelce,KC,TE,55
+Nick H.,28,Tee Higgins,Cin,WR,26
+Nick H.,34,CeeDee Lamb,Dal,WR,46
+Nick H.,41,Jahmyr Gibbs,Det,RB,21
+Nick H.,59,DeVonta Smith,Phi,WR,24
+Nick H.,61,James Cook,Buf,RB,9
+Nick H.,76,Trevor Lawrence,Jax,QB,2
+Nick H.,83,David Montgomery,Det,RB,6
+Nick H.,108,JuJu Smith-Schuster,NE,WR,2
+Nick H.,113,Daniel Carlson,LV,K,1
+Nick H.,123,Allen Lazard,NYJ,WR,1
+Nick H.,131,Adam Thielen,Car,WR,2
+Nick H.,133,Ravens D/ST,Bal,D/ST,1
+Nick H.,142,K.J. Osborn,NE,WR,1
+Nick H.,149,Tyler Higbee,LAR,TE,1
+Nick H.,156,Gus Edwards,LAC,RB,1
+Nick H.,163,Hunter Renfrow,LV,WR,1
 Diego,26,DK Metcalf,Sea,WR,30
 Diego,29,Lamar Jackson,Bal,QB,21
 Diego,31,Rhamondre Stevenson,NE,RB,18

--- a/data/raw/2024/draft_rankings.csv
+++ b/data/raw/2024/draft_rankings.csv
@@ -16,23 +16,23 @@ Dane,119,Jordan Mason,Min,RB,1
 Dane,129,Cole Kmet,Chi,TE,1
 Dane,139,Jerry Jeudy,Cle,WR,1
 Dane,148,Justin Herbert,LAC,QB,1
-Nick H,17,Chris Olave,NO,WR,30
-Nick H,26,De'Von Achane,Mia,RB,26
-Nick H,28,Michael Pittman Jr.,Ind,WR,26
-Nick H,43,Alvin Kamara,NO,RB,31
-Nick H,46,Cooper Kupp,Sea,WR,31
-Nick H,53,DeVonta Smith,Phi,WR,22
-Nick H,69,Aaron Jones,Min,RB,8
-Nick H,75,Dalton Kincaid,Buf,TE,7
-Nick H,79,Raheem Mostert,LV,RB,5
-Nick H,81,Tyjae Spears,Ten,RB,2
-Nick H,86,Christian Kirk,Hou,WR,3
-Nick H,91,Kyler Murray,Ari,QB,2
-Nick H,94,Jayden Reed,GB,WR,1
-Nick H,114,Dallas Goedert,Phi,TE,1
-Nick H,115,Jameson Williams,Det,WR,2
-Nick H,124,Brandon Aubrey,Dal,K,1
-Nick H,134,Jets D/ST,NYJ,D/ST,1
+Nick H.,17,Chris Olave,NO,WR,30
+Nick H.,26,De'Von Achane,Mia,RB,26
+Nick H.,28,Michael Pittman Jr.,Ind,WR,26
+Nick H.,43,Alvin Kamara,NO,RB,31
+Nick H.,46,Cooper Kupp,Sea,WR,31
+Nick H.,53,DeVonta Smith,Phi,WR,22
+Nick H.,69,Aaron Jones,Min,RB,8
+Nick H.,75,Dalton Kincaid,Buf,TE,7
+Nick H.,79,Raheem Mostert,LV,RB,5
+Nick H.,81,Tyjae Spears,Ten,RB,2
+Nick H.,86,Christian Kirk,Hou,WR,3
+Nick H.,91,Kyler Murray,Ari,QB,2
+Nick H.,94,Jayden Reed,GB,WR,1
+Nick H.,114,Dallas Goedert,Phi,TE,1
+Nick H.,115,Jameson Williams,Det,WR,2
+Nick H.,124,Brandon Aubrey,Dal,K,1
+Nick H.,134,Jets D/ST,NYJ,D/ST,1
 Diego,4,Bijan Robinson,Atl,RB,53
 Diego,9,A.J. Brown,Phi,WR,51
 Diego,21,Josh Jacobs,GB,RB,32

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.67.0",
+      "version": "1.67.1",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.67.0",
+  "version": "1.67.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/public/data/2022/draft-rankings.json
+++ b/frontend/public/data/2022/draft-rankings.json
@@ -136,7 +136,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 7,
     "player": "Justin Jefferson",
     "nfl_team": "Min",
@@ -144,7 +144,7 @@
     "offer_amount": 52
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 9,
     "player": "Joe Mixon",
     "nfl_team": "Cin",
@@ -152,7 +152,7 @@
     "offer_amount": 46
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 33,
     "player": "T.J. Hockenson",
     "nfl_team": "Min",
@@ -160,7 +160,7 @@
     "offer_amount": 8
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 34,
     "player": "Javonte Williams",
     "nfl_team": "Den",
@@ -168,7 +168,7 @@
     "offer_amount": 38
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 38,
     "player": "Cam Akers",
     "nfl_team": "LAR",
@@ -176,7 +176,7 @@
     "offer_amount": 27
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 52,
     "player": "Diontae Johnson",
     "nfl_team": "Pit",
@@ -184,7 +184,7 @@
     "offer_amount": 16
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 85,
     "player": "Kareem Hunt",
     "nfl_team": "Cle",
@@ -192,7 +192,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 87,
     "player": "Russell Wilson",
     "nfl_team": "Den",
@@ -200,7 +200,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 90,
     "player": "Rashod Bateman",
     "nfl_team": "Bal",
@@ -208,7 +208,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 100,
     "player": "Dallas Goedert",
     "nfl_team": "Phi",
@@ -216,7 +216,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 110,
     "player": "Tom Brady",
     "nfl_team": "TB",
@@ -224,7 +224,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 119,
     "player": "Garrett Wilson",
     "nfl_team": "NYJ",
@@ -232,7 +232,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 128,
     "player": "Trey Lance",
     "nfl_team": "SF",
@@ -240,7 +240,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 137,
     "player": "Robbie Anderson",
     "nfl_team": "FA",
@@ -248,7 +248,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 145,
     "player": "Darrell Henderson Jr.",
     "nfl_team": "FA",
@@ -256,7 +256,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 153,
     "player": "Steelers D/ST",
     "nfl_team": "Pit",
@@ -264,7 +264,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 161,
     "player": "Matt Prater",
     "nfl_team": "Ari",

--- a/frontend/public/data/2023/draft-rankings.json
+++ b/frontend/public/data/2023/draft-rankings.json
@@ -136,7 +136,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 15,
     "player": "Travis Kelce",
     "nfl_team": "KC",
@@ -144,7 +144,7 @@
     "offer_amount": 55
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 28,
     "player": "Tee Higgins",
     "nfl_team": "Cin",
@@ -152,7 +152,7 @@
     "offer_amount": 26
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 34,
     "player": "CeeDee Lamb",
     "nfl_team": "Dal",
@@ -160,7 +160,7 @@
     "offer_amount": 46
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 41,
     "player": "Jahmyr Gibbs",
     "nfl_team": "Det",
@@ -168,7 +168,7 @@
     "offer_amount": 21
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 59,
     "player": "DeVonta Smith",
     "nfl_team": "Phi",
@@ -176,7 +176,7 @@
     "offer_amount": 24
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 61,
     "player": "James Cook",
     "nfl_team": "Buf",
@@ -184,7 +184,7 @@
     "offer_amount": 9
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 76,
     "player": "Trevor Lawrence",
     "nfl_team": "Jax",
@@ -192,7 +192,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 83,
     "player": "David Montgomery",
     "nfl_team": "Det",
@@ -200,7 +200,7 @@
     "offer_amount": 6
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 108,
     "player": "JuJu Smith-Schuster",
     "nfl_team": "NE",
@@ -208,7 +208,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 113,
     "player": "Daniel Carlson",
     "nfl_team": "LV",
@@ -216,7 +216,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 123,
     "player": "Allen Lazard",
     "nfl_team": "NYJ",
@@ -224,7 +224,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 131,
     "player": "Adam Thielen",
     "nfl_team": "Car",
@@ -232,7 +232,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 133,
     "player": "Ravens D/ST",
     "nfl_team": "Bal",
@@ -240,7 +240,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 142,
     "player": "K.J. Osborn",
     "nfl_team": "NE",
@@ -248,7 +248,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 149,
     "player": "Tyler Higbee",
     "nfl_team": "LAR",
@@ -256,7 +256,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 156,
     "player": "Gus Edwards",
     "nfl_team": "LAC",
@@ -264,7 +264,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 163,
     "player": "Hunter Renfrow",
     "nfl_team": "LV",

--- a/frontend/public/data/2024/draft-rankings.json
+++ b/frontend/public/data/2024/draft-rankings.json
@@ -136,7 +136,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 17,
     "player": "Chris Olave",
     "nfl_team": "NO",
@@ -144,7 +144,7 @@
     "offer_amount": 30
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 26,
     "player": "De'Von Achane",
     "nfl_team": "Mia",
@@ -152,7 +152,7 @@
     "offer_amount": 26
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 28,
     "player": "Michael Pittman Jr.",
     "nfl_team": "Ind",
@@ -160,7 +160,7 @@
     "offer_amount": 26
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 43,
     "player": "Alvin Kamara",
     "nfl_team": "NO",
@@ -168,7 +168,7 @@
     "offer_amount": 31
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 46,
     "player": "Cooper Kupp",
     "nfl_team": "Sea",
@@ -176,7 +176,7 @@
     "offer_amount": 31
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 53,
     "player": "DeVonta Smith",
     "nfl_team": "Phi",
@@ -184,7 +184,7 @@
     "offer_amount": 22
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 69,
     "player": "Aaron Jones",
     "nfl_team": "Min",
@@ -192,7 +192,7 @@
     "offer_amount": 8
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 75,
     "player": "Dalton Kincaid",
     "nfl_team": "Buf",
@@ -200,7 +200,7 @@
     "offer_amount": 7
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 79,
     "player": "Raheem Mostert",
     "nfl_team": "LV",
@@ -208,7 +208,7 @@
     "offer_amount": 5
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 81,
     "player": "Tyjae Spears",
     "nfl_team": "Ten",
@@ -216,7 +216,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 86,
     "player": "Christian Kirk",
     "nfl_team": "Hou",
@@ -224,7 +224,7 @@
     "offer_amount": 3
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 91,
     "player": "Kyler Murray",
     "nfl_team": "Ari",
@@ -232,7 +232,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 94,
     "player": "Jayden Reed",
     "nfl_team": "GB",
@@ -240,7 +240,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 114,
     "player": "Dallas Goedert",
     "nfl_team": "Phi",
@@ -248,7 +248,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 115,
     "player": "Jameson Williams",
     "nfl_team": "Det",
@@ -256,7 +256,7 @@
     "offer_amount": 2
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 124,
     "player": "Brandon Aubrey",
     "nfl_team": "Dal",
@@ -264,7 +264,7 @@
     "offer_amount": 1
   },
   {
-    "manager": "Nick H",
+    "manager": "Nick H.",
     "rank": 134,
     "player": "Jets D/ST",
     "nfl_team": "NYJ",


### PR DESCRIPTION
QA follow-up: normalize Nick H. across the 2022–2024 CSV and generated JSON files, verify CSV/JSON parity, and release as v1.67.1.