### PR TITLE
Add historic draft season navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.68.1",
+  "version": "1.69.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rankingsdiff-frontend",
-      "version": "1.68.1",
+      "version": "1.69.0",
       "dependencies": {
         "@vitejs/plugin-react": "5.0.0",
         "react": "18.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rankingsdiff-frontend",
-  "version": "1.68.1",
+  "version": "1.69.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,6 +109,14 @@ function AppData() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
+  function navigateDraftSeason(nextSeason: 2022 | 2023 | 2024 | 2025) {
+    const path = `${import.meta.env.BASE_URL}draft-rankings/${nextSeason}`
+    window.history.pushState({}, '', path)
+    setRoute('draft')
+    setDraftSeason(nextSeason)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
   useEffect(() => {
     const controller = new AbortController()
     const timeout = window.setTimeout(() => controller.abort(), 12000)
@@ -192,7 +200,7 @@ function AppData() {
   if (error) return <ErrorState message={error} onRetry={() => { setRows([]); setRowsLoading(true); setHasLoadedRows(false); setRetryKey((current) => current + 1) }} />
   if (manifestLoading || !manifest.seasons.length || !selectedSource || !hasLoadedRows) return <LoadingState detail={manifestLoading ? undefined : `Loading ${selectedMeta?.label ?? 'the selected source'} rankings…`} />
 
-  if (route === 'draft') return <DraftRankingsPage season={draftSeason} rows={draftRowsBySeason[draftSeason] ?? []} rowsBySeason={draftRowsBySeason} onNavigate={navigate} />
+  if (route === 'draft') return <DraftRankingsPage season={draftSeason} rows={draftRowsBySeason[draftSeason] ?? []} rowsBySeason={draftRowsBySeason} onNavigate={navigate} onSeason={navigateDraftSeason} />
 
   const displayedRows = applyAdjustedProfile(rows, selectedProfile?.id ?? 'full-ppr', selectedSource)
   return <RankingsDashboard manifest={manifest} rows={displayedRows} teams={teams} yahooProjections={yahooProjections} sourceChecks={sourceChecks} selectedSeason={selectedSeason} selectedSource={selectedSource} adjustedProfiles={adjustedProfiles} selectedAdjustedProfile={selectedProfile?.id ?? 'full-ppr'} onAdjustedProfile={setSelectedAdjustedProfile} onSeason={handleSeason} onSource={setSelectedSource} route={route} onNavigate={navigate} />

--- a/frontend/src/components/DraftRankingsPage.tsx
+++ b/frontend/src/components/DraftRankingsPage.tsx
@@ -3,7 +3,7 @@ import type { DraftRankingRow } from '../types'
 import { ViewTabs } from './ViewTabs'
 
 type SortKey = 'rank' | 'player' | 'position' | 'offer_amount' | 'espn_suggested_value' | 'value_diff' | 'manager' | 'nfl_team'
-type Props = { season: 2022 | 2023 | 2024 | 2025; rows: DraftRankingRow[]; rowsBySeason: Record<number, DraftRankingRow[]>; onNavigate: (path: 'board' | 'analytics' | 'draft') => void }
+type Props = { season: 2022 | 2023 | 2024 | 2025; rows: DraftRankingRow[]; rowsBySeason: Record<number, DraftRankingRow[]>; onNavigate: (path: 'board' | 'analytics' | 'draft') => void; onSeason: (season: 2022 | 2023 | 2024 | 2025) => void }
 type HistoricalPosition = 'RB' | 'WR' | 'QB' | 'TE'
 
 const POSITION_ORDER = ['ALL', 'QB', 'RB', 'WR', 'TE', 'K', 'D/ST']
@@ -20,7 +20,7 @@ const ESPN_REFERENCE_URLS: Record<number, string> = {
 function money(value: number): string { return `$${value}` }
 function delta(value: number): string { return `${value > 0 ? '+' : ''}${money(value)}` }
 
-export function DraftRankingsPage({ season, rows, rowsBySeason, onNavigate }: Props) {
+export function DraftRankingsPage({ season, rows, rowsBySeason, onNavigate, onSeason }: Props) {
   const [view, setView] = useState<'results' | 'averages'>('results')
   const [averagePosition, setAveragePosition] = useState<HistoricalPosition>('RB')
   const [position, setPosition] = useState('ALL')
@@ -65,6 +65,7 @@ export function DraftRankingsPage({ season, rows, rowsBySeason, onNavigate }: Pr
     </section>
 
     <section className="draft-view-switcher" aria-label="Historic results views"><button type="button" className={view === 'results' ? 'active' : ''} onClick={() => setView('results')}>Player results</button><button type="button" className={view === 'averages' ? 'active' : ''} onClick={() => setView('averages')}>League averages</button></section>
+    <nav className="historic-season-tabs" aria-label="Draft season">{([2022, 2023, 2024, 2025] as const).map((year) => <button type="button" key={year} className={season === year ? 'active' : ''} aria-current={season === year ? 'page' : undefined} onClick={() => onSeason(year)}>{year}</button>)}</nav>
 
     {view === 'averages' ? <section className="historic-averages" aria-label="League average auction prices">
       <div className="historic-averages__intro"><div><span className="eyebrow">Across 2022–2025</span><h2>League average prices</h2><p>Compare the average auction cost and total spend for each positional slot across the four historical drafts.</p></div><div className="position-pills">{HISTORIC_POSITIONS.map((key) => <button type="button" key={key} className={averagePosition === key ? 'active' : ''} onClick={() => setAveragePosition(key)}>{key} · top {HISTORIC_LIMITS[key]}</button>)}</div></div>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -2168,6 +2168,10 @@ tbody tr.is-drafted .draft-action.active { border-color: var(--line); color: var
 .draft-view-switcher { display: flex; gap: 4px; width: fit-content; margin: 14px 0 16px; padding: 4px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
 .draft-view-switcher button { border: 0; border-radius: 8px; padding: 8px 13px; color: var(--muted); background: transparent; font-size: .78rem; font-weight: 850; }
 .draft-view-switcher button.active { color: var(--ink); background: var(--accent-soft); }
+.historic-season-tabs { display: flex; gap: 4px; width: fit-content; margin: -6px 0 16px; padding: 4px; border: 1px solid var(--line); border-radius: 12px; background: var(--panel); }
+.historic-season-tabs button { min-width: 52px; border: 0; border-radius: 8px; padding: 8px 11px; color: var(--muted); background: transparent; font-size: .78rem; font-weight: 850; }
+.historic-season-tabs button.active { color: var(--ink); background: var(--accent-soft); }
+.historic-season-tabs button:hover, .historic-season-tabs button:focus-visible { color: var(--accent); }
 .historic-averages { display: grid; gap: 14px; }
 .historic-averages__intro { display: flex; justify-content: space-between; gap: 24px; align-items: end; padding: 18px; border: 1px solid var(--line); border-radius: 14px; background: var(--panel); box-shadow: var(--shadow-sm); }
 .historic-averages__intro h2 { margin: 4px 0; font-size: 1.25rem; letter-spacing: -.04em; }

--- a/frontend/tests/app.spec.cjs
+++ b/frontend/tests/app.spec.cjs
@@ -122,6 +122,20 @@ test('2022 auction rankings loads from its own direct route', async ({ page }) =
   await expect(page.getByText('Adrian', { exact: true }).first()).toBeVisible()
 })
 
+test('historic player results can switch seasons', async ({ page }) => {
+  await page.goto('./draft-rankings/2025')
+  await expect(page.locator('.historic-season-tabs button.active')).toHaveText('2025')
+  await page.getByRole('button', { name: '2023', exact: true }).click()
+  await expect(page).toHaveURL(/\/draft-rankings\/2023$/)
+  await expect(page.getByRole('heading', { name: '2023 Draft' })).toBeVisible()
+  await expect(page.getByText('Justin Jefferson · $63').first()).toBeVisible()
+  await expect(page.locator('.historic-season-tabs button.active')).toHaveText('2023')
+  await page.getByRole('button', { name: '2022', exact: true }).click()
+  await expect(page).toHaveURL(/\/draft-rankings\/2022$/)
+  await expect(page.getByRole('heading', { name: '2022 Draft' })).toBeVisible()
+  await expect(page.locator('.historic-season-tabs button.active')).toHaveText('2022')
+})
+
 test('historic results offers positional league averages across all seasons', async ({ page }) => {
   await page.goto('./draft-rankings/2025')
   await page.getByRole('button', { name: 'League averages', exact: true }).click()


### PR DESCRIPTION
## Summary
- add compact 2022–2025 season tabs to Historic results
- make Player results and League averages follow the selected historic season
- add regression coverage and release version 1.69.0

## Validation
- `asdf exec npm --prefix frontend run lint`
- `asdf exec npm --prefix frontend run test`
- `asdf exec npm --prefix frontend run build`
- `PLAYWRIGHT_PORT=5200 asdf exec npm --prefix frontend run test:ui`